### PR TITLE
Implement Gamma Correction for LedProgressGrid

### DIFF
--- a/design/COMPONENT_LIBRARIES.md
+++ b/design/COMPONENT_LIBRARIES.md
@@ -81,6 +81,7 @@ The `LedProgressGrid` component manages an 8x8 NeoPixel grid to display player s
     -   **5-8 Players:** Each player gets one row, starting with Player 1 at row 0.
 -   **Snaking Pixel Layout:** The underlying NeoPixel hardware is assumed to be wired in a snaking pattern, which is handled by the `get_pixel_index` helper.
 -   **Internal `maxScore` Calculation:** The `update` method calculates the effective `maxScore` for display scaling based on game rules (multiples of 2000, min 10000).
+-   **Non-Linear Brightness (Gamma Correction):** To align with human visual perception, the "remainder" pixel (the partially lit LED at the end of a bar) uses a squared brightness curve ($brightness = remainder^2 \times max\_brightness$). This ensures that small increases at the low end of the scale (0-10%) result in smaller visual changes than linear increases, preventing the "jumpy" look of linear PWM.
 -   **Blinking:** Blinking effects for at-risk scores and pending players are handled internally, using `millis()` for timing.
 
 ---

--- a/design/GENERAL_GAME_PLAY.md
+++ b/design/GENERAL_GAME_PLAY.md
@@ -46,6 +46,7 @@ The game begins by guiding players through setup and configuration.
 ### 2.2 Score Animations
 -   **Banking Animation:**
     -   When a player presses `BANK`, their `atRisk` score slowly drains to zero while their banked score simultaneously increases by the same amount. Both the `ScoreDisplay` segments and the `LedProgressGrid` animate this proportional change, with the `atRisk` portion shrinking and the banked portion growing.
+    -   **Note on Visuals:** The `LedProgressGrid` uses a logarithmic/exponential brightness curve for the "remainder" pixel. This ensures that the visual progression appears smooth and linear to the human eye, avoiding sudden jumps in brightness during these animations.
     -   Input is locked during this animation.
 -   **Standard Farkle Animation:**
     -   If a player farkles (but it's not their third consecutive farkle), their `atRisk` score slowly drains to zero.

--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
@@ -27,7 +27,8 @@ void LedProgressGrid::hello_world()
 void LedProgressGrid::illuminate_row(int row, uint16_t hue, float ratio, uint8_t brightness) {
   int num_pixels = (int) (ratio * GRID_LENGTH);
   float remainder = (ratio * GRID_LENGTH) - num_pixels;
-  int remaininderBrightness = remainder * brightness;
+  // Apply a square curve (gamma ~2.0) to the remainder for smoother perceived brightness transitions
+  int remaininderBrightness = (int)(remainder * remainder * brightness);
   // rows snake, so we need to count backwards for odd rows
     for (int col = 0; col < num_pixels; ++col) {
       _pixels.setPixelColor(


### PR DESCRIPTION
- Updated `LedProgressGrid::illuminate_row` to use a squared brightness curve for the remainder pixel. This aligns the visual brightness with human perception, making low-end score changes less abrupt.
- Updated `design/COMPONENT_LIBRARIES.md` to document the new non-linear brightness logic.
- Updated `design/GENERAL_GAME_PLAY.md` to include a note about the visual behavior in the "Score Animations" section.

---
*PR created automatically by Jules for task [1480937283409443903](https://jules.google.com/task/1480937283409443903) started by @gwenrich136*