### PR TITLE
Wait for dismissal in Banking/Farkling phases

### DIFF
--- a/src/farkle/src/phases/BankingPhase.cpp
+++ b/src/farkle/src/phases/BankingPhase.cpp
@@ -10,35 +10,40 @@ void BankingPhase::onEnter(GameState& state) {
 
 GamePhase* BankingPhase::update(Game& game, GameState& state, ButtonAction action, unsigned long deltaTime) {
     // 1. Perform Animation
-    scoreMoveAccumulator += (SCORE_ANIMATION_SPEED * deltaTime);
-    int pointsToMove = (int)scoreMoveAccumulator;
-    
-    if (pointsToMove > 0) {
-        // Ensure we don't move more than what's left in atRiskScore
-        if (pointsToMove > state.atRiskScore) {
-            pointsToMove = state.atRiskScore;
-        }
+    if (state.atRiskScore > 0) {
+        scoreMoveAccumulator += (SCORE_ANIMATION_SPEED * deltaTime);
+        int pointsToMove = (int)scoreMoveAccumulator;
         
-        state.players[state.currentPlayerIndex].score += pointsToMove;
-        state.atRiskScore -= pointsToMove;
-        scoreMoveAccumulator -= (float)pointsToMove;
+        if (pointsToMove > 0) {
+            // Ensure we don't move more than what's left in atRiskScore
+            if (pointsToMove > state.atRiskScore) {
+                pointsToMove = state.atRiskScore;
+            }
+
+            state.players[state.currentPlayerIndex].score += pointsToMove;
+            state.atRiskScore -= pointsToMove;
+            scoreMoveAccumulator -= (float)pointsToMove;
+        }
     }
 
     // 2. Check for completion
     if (state.atRiskScore <= 0) {
         state.atRiskScore = 0; // Clean up any fractional remainder
 
-        // Reset farkle count on a successful bank
-        state.players[state.currentPlayerIndex].farkle_count = 0;
+        // Wait for user dismissal (any button press)
+        if (action != ButtonAction::NONE) {
+            // Reset farkle count on a successful bank
+            state.players[state.currentPlayerIndex].farkle_count = 0;
 
-        // Check for Final Round Trigger
-        if (!state.finalRoundTriggered && state.players[state.currentPlayerIndex].score >= 5000) {
-            state.finalRoundTriggered = true;
+            // Check for Final Round Trigger
+            if (!state.finalRoundTriggered && state.players[state.currentPlayerIndex].score >= 5000) {
+                state.finalRoundTriggered = true;
+            }
+
+            // Advance turn and transition
+            this->endTurn(state);
+            return game.getPhase<WaitingPhase>();
         }
-
-        // Advance turn and transition
-        this->endTurn(state);
-        return game.getPhase<WaitingPhase>();
     }
 
     return this;

--- a/src/farkle/src/phases/FarklingPhase.cpp
+++ b/src/farkle/src/phases/FarklingPhase.cpp
@@ -17,22 +17,28 @@ void FarklingPhase::onEnter(GameState& state) {
 
 GamePhase* FarklingPhase::update(Game& game, GameState& state, ButtonAction action, unsigned long deltaTime) {
     // 1. Perform Animation
-    scoreMoveAccumulator += (FARKLE_DRAIN_SPEED * deltaTime);
-    int pointsToDrain = (int)scoreMoveAccumulator;
+    if (state.atRiskScore > 0) {
+        scoreMoveAccumulator += (FARKLE_DRAIN_SPEED * deltaTime);
+        int pointsToDrain = (int)scoreMoveAccumulator;
 
-    if (pointsToDrain > 0) {
-        if (pointsToDrain > state.atRiskScore) {
-            pointsToDrain = state.atRiskScore;
+        if (pointsToDrain > 0) {
+            if (pointsToDrain > state.atRiskScore) {
+                pointsToDrain = state.atRiskScore;
+            }
+            state.atRiskScore -= pointsToDrain;
+            scoreMoveAccumulator -= (float)pointsToDrain;
         }
-        state.atRiskScore -= pointsToDrain;
-        scoreMoveAccumulator -= (float)pointsToDrain;
     }
 
     // 2. Check for completion
     if (state.atRiskScore <= 0) {
         state.atRiskScore = 0;
-        this->endTurn(state);
-        return game.getPhase<WaitingPhase>();
+
+        // Wait for user dismissal
+        if (action != ButtonAction::NONE) {
+            this->endTurn(state);
+            return game.getPhase<WaitingPhase>();
+        }
     }
 
     return this;


### PR DESCRIPTION
Implemented the requirement for the game to pause and wait for user interaction (any button press) after the banking or farkling animations complete, preventing an immediate transition to the next player's turn.

This addresses Issue 4 and aligns with the V1 design decision to keep text display simple (player name only) during this wait state.

---
*PR created automatically by Jules for task [11107115506554402200](https://jules.google.com/task/11107115506554402200) started by @gwenrich136*