### PR TITLE
⚡ Optimize LedProgressGrid loop performance

### DIFF
--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
@@ -18,10 +18,11 @@ void LedProgressGrid::illuminate_row(int row, uint16_t hue, float ratio, uint8_t
   int num_pixels = (int) (ratio * GRID_LENGTH);
   float remainder = (ratio * GRID_LENGTH) - num_pixels;
   // rows snake, so we need to count backwards for odd rows
+    uint32_t color = _pixels.ColorHSV(hue, 255, brightness);
     for (int col = 0; col < num_pixels; ++col) {
       _pixels.setPixelColor(
         get_pixel_index(row, col),
-        _pixels.ColorHSV(hue, 255, brightness));
+        color);
     }
     // Only draw partial pixel if we haven't filled the row
     if (num_pixels < GRID_LENGTH) {


### PR DESCRIPTION
Implemented a performance optimization in `LedProgressGrid::illuminate_row` by calculating the pixel color once before the loop instead of recalculating it for every pixel. This saves redundant calculations and improves the efficiency of the LED update cycle.

**Performance Impact:**
- Eliminates `N` calls to `ColorHSV` (HSV to RGB conversion) per row update, where `N` is the number of pixels in the row.

**Verification:**
- Compiled successfully for `uno_r4_wifi`.
- Code review approved.
- Existing tests preserved.

---
*PR created automatically by Jules for task [9452231827050129180](https://jules.google.com/task/9452231827050129180) started by @gwenrich136*