### PR TITLE
⚡ Optimize ScoreDisplay: Remove heap allocation

### DIFF
--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -125,3 +125,22 @@ We will structure our tests into three tiers based on scope and complexity. This
 3.  **Implement Fake Logic:** Update `FakeScoreDisplay.cpp` to store values in public variables for inspection.
 4.  **Write Tests:** Create `test/test_game_logic/test_transitions.cpp` using the Unity `TEST_ASSERT` macros.
 5.  **Run:** Execute `pio test -e native`.
+
+## 6. Component Performance Testing
+
+To verify the performance and correctness of individual hardware components (like `ScoreDisplay`) without flashing hardware, we use a specialized test environment `env:component_tests`.
+
+### 6.1 Strategy
+*   **Real Component Code:** compiled directly from `lib/components`.
+*   **Mocked Dependencies:** External hardware libraries (like `LedControl`) are mocked in `test/mocks/libs`.
+*   **Performance Benchmarking:** Tests include timing measurements to detect regressions or verify optimizations.
+
+### 6.2 Running Component Tests
+To run these tests, use the PlatformIO CLI:
+```bash
+pio test -e component_tests
+```
+
+### 6.3 Directory Structure
+*   `test/test_component_tests/`: Contains the test suites for components.
+*   `test/mocks/libs/`: Contains mocks for external libraries used by components.

--- a/src/farkle/lib/components/ScoreDisplay/ScoreDisplay.cpp
+++ b/src/farkle/lib/components/ScoreDisplay/ScoreDisplay.cpp
@@ -22,13 +22,29 @@ void ScoreDisplay::begin() {
 
 void ScoreDisplay::print_number(int number, int deviceIndex)
 {
-  const int numberToDisplay = number % 100000;
-  std::string numberStr = std::to_string(numberToDisplay);
-  const int emptySlots = NUM_DIGITS_PER_DISPLAY - numberStr.length();
+  int numberToDisplay = number % 100000;
+
+  char digits[12];
+  int len = 0;
+
+  if (numberToDisplay == 0) {
+    digits[len++] = '0';
+  } else {
+    bool negative = numberToDisplay < 0;
+    if (negative) numberToDisplay = -numberToDisplay;
+
+    while (numberToDisplay > 0) {
+      digits[len++] = (numberToDisplay % 10) + '0';
+      numberToDisplay /= 10;
+    }
+    if (negative) digits[len++] = '-';
+  }
+
+  const int emptySlots = NUM_DIGITS_PER_DISPLAY - len;
   for (int i = 0; i < emptySlots; ++i) {
     _lc.setChar(deviceIndex, i, ' ', false);
   }
-  for (int i = 0; i < numberStr.length(); ++i){
-    _lc.setChar(deviceIndex, i + emptySlots, numberStr.at(i), false);
+  for (int i = 0; i < len; ++i){
+    _lc.setChar(deviceIndex, i + emptySlots, digits[len - 1 - i], false);
   }
 }

--- a/src/farkle/platformio.ini
+++ b/src/farkle/platformio.ini
@@ -31,3 +31,14 @@ test_build_src = yes
 build_src_filter = +<*> -<main.cpp> +<../test/mocks/src/>
 test_filter = test_game_logic
 
+[env:component_tests]
+extends = env:native
+test_filter = test_component_tests
+lib_ignore =
+build_flags =
+  -Iinclude
+  -Ilib/components/ScoreDisplay
+  -Itest/mocks/include
+  -Itest/mocks/libs
+  -DUNIT_TEST
+build_src_filter = +<*> -<main.cpp> +<../test/mocks/src/> -<../test/mocks/src/ScoreDisplay.cpp> +<../lib/components/ScoreDisplay/ScoreDisplay.cpp>

--- a/src/farkle/test/mocks/libs/LedControl.h
+++ b/src/farkle/test/mocks/libs/LedControl.h
@@ -1,0 +1,30 @@
+#ifndef LEDCONTROL_H
+#define LEDCONTROL_H
+
+#include <stdint.h>
+#include <map>
+#include <string> // Required for current ScoreDisplay implementation
+
+// Global state for verification
+// Map<DeviceIndex, Map<DigitIndex, Character>>
+extern std::map<int, std::map<int, char>> mockLedState;
+
+class LedControl {
+public:
+    LedControl(int dataPin, int clkPin, int csPin, int numDevices) {
+    }
+
+    void shutdown(int addr, bool b) {}
+
+    void setIntensity(int addr, int intensity) {}
+
+    void clearDisplay(int addr) {
+        mockLedState[addr].clear();
+    }
+
+    void setChar(int addr, int digit, char value, bool dp) {
+        mockLedState[addr][digit] = value;
+    }
+};
+
+#endif

--- a/src/farkle/test/test_component_tests/test_score_display.cpp
+++ b/src/farkle/test/test_component_tests/test_score_display.cpp
@@ -1,0 +1,94 @@
+#include <unity.h>
+#include <map>
+#include <iostream>
+#include <chrono>
+#include "ScoreDisplay.h"
+
+// Define the global mock state
+std::map<int, std::map<int, char>> mockLedState;
+
+ScoreDisplay* display;
+
+void setUp(void) {
+    mockLedState.clear();
+    // Pins don't matter for mock
+    display = new ScoreDisplay(10, 11, 12);
+    display->begin();
+}
+
+void tearDown(void) {
+    delete display;
+}
+
+void test_ScoreDisplay_Correctness_Zero(void) {
+    display->print_number(0, 0);
+    // Expect "    0" (4 spaces, 1 zero)
+    // Note: implementation depends on how many digits are flushed.
+    // print_number fills 'emptySlots' with ' ', then the number.
+    // It assumes NUM_DIGITS_PER_DISPLAY = 5.
+
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][0]);
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][1]);
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][2]);
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][3]);
+    TEST_ASSERT_EQUAL_CHAR('0', mockLedState[0][4]);
+}
+
+void test_ScoreDisplay_Correctness_Number(void) {
+    display->print_number(123, 0);
+    // Expect "  123"
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][0]);
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][1]);
+    TEST_ASSERT_EQUAL_CHAR('1', mockLedState[0][2]);
+    TEST_ASSERT_EQUAL_CHAR('2', mockLedState[0][3]);
+    TEST_ASSERT_EQUAL_CHAR('3', mockLedState[0][4]);
+}
+
+void test_ScoreDisplay_Correctness_Full(void) {
+    display->print_number(54321, 0);
+    // Expect "54321"
+    TEST_ASSERT_EQUAL_CHAR('5', mockLedState[0][0]);
+    TEST_ASSERT_EQUAL_CHAR('4', mockLedState[0][1]);
+    TEST_ASSERT_EQUAL_CHAR('3', mockLedState[0][2]);
+    TEST_ASSERT_EQUAL_CHAR('2', mockLedState[0][3]);
+    TEST_ASSERT_EQUAL_CHAR('1', mockLedState[0][4]);
+}
+
+void test_ScoreDisplay_Correctness_Overflow(void) {
+    // Current implementation: number % 100000
+    // 100001 -> 1
+    display->print_number(100001, 0);
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][0]);
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][1]);
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][2]);
+    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][3]);
+    TEST_ASSERT_EQUAL_CHAR('1', mockLedState[0][4]);
+}
+
+void test_ScoreDisplay_Performance(void) {
+    const int iterations = 10000;
+    auto start = std::chrono::high_resolution_clock::now();
+
+    // We mix some calls to prevent compiler from optimizing too much if it could,
+    // though for side-effects it shouldn't.
+    for (int i = 0; i < iterations; i++) {
+        display->print_number(12345, 0);
+        display->print_number(123, 0);
+        display->print_number(0, 0);
+    }
+
+    auto end = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+
+    std::cout << "PERFORMANCE_RESULT: " << duration.count() << " microseconds for " << (iterations * 3) << " calls" << std::endl;
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_ScoreDisplay_Correctness_Zero);
+    RUN_TEST(test_ScoreDisplay_Correctness_Number);
+    RUN_TEST(test_ScoreDisplay_Correctness_Full);
+    RUN_TEST(test_ScoreDisplay_Correctness_Overflow);
+    RUN_TEST(test_ScoreDisplay_Performance);
+    return UNITY_END();
+}


### PR DESCRIPTION
Replaced `std::string` and `std::to_string` with integer math in `ScoreDisplay::print_number` to avoid heap allocations. Added a dedicated component testing environment and benchmark. Measured ~3% performance improvement on host (baseline: 42079us, optimized: 40833us for 30k calls) and eliminated heap usage for this critical path.

---
*PR created automatically by Jules for task [2371767175453221184](https://jules.google.com/task/2371767175453221184) started by @gwenrich136*