### PR TITLE
Update farkle count reset behavior to happen immediately upon banking

### DIFF
--- a/design/GENERAL_GAME_PLAY.md
+++ b/design/GENERAL_GAME_PLAY.md
@@ -46,6 +46,7 @@ The game begins by guiding players through setup and configuration.
 ### 2.2 Score Animations
 -   **Banking Animation:**
     -   When a player presses `BANK`, their `atRisk` score slowly drains to zero while their banked score simultaneously increases by the same amount. Both the `ScoreDisplay` segments and the `LedProgressGrid` animate this proportional change, with the `atRisk` portion shrinking and the banked portion growing.
+    - The player's consecutive farkle count is also reset to zero at the beginning of this phase, causing the `FarkleWarningLights` to turn off immediately.
     -   **Note on Visuals:** The `LedProgressGrid` uses a logarithmic/exponential brightness curve for the "remainder" pixel. This ensures that the visual progression appears smooth and linear to the human eye, avoiding sudden jumps in brightness during these animations.
     -   Input is locked during this animation.
     -   **Manual Advance:** Once the animation completes (at-risk score is 0), the game persists in its final state, showing the updated score. The game waits indefinitely until **any button** is pressed on the `ControlPad`.

--- a/design/TECHNICAL_DESIGN_GAME_STATE_MACHINE.md
+++ b/design/TECHNICAL_DESIGN_GAME_STATE_MACHINE.md
@@ -123,7 +123,8 @@ A new directory `src/farkle/src/phases/` will be created to house these files.
 
 *   **`src/farkle/include/phases/BankingPhase.h`** & **`src/farkle/src/phases/BankingPhase.cpp`**
     *   **Why:** Implements the banking animation and the end-of-turn logic that follows.
-    *   **Implementation Details:** The `update()` method will handle both the animation and the subsequent wait for dismissal:
+    *   **Implementation Details:**
+        0.  **Reset Farkle Count:** The `onEnter()` method will reset the current player's `farkle_count` to 0.
         1.  **Animate Score Transfer:** While `state.atRiskScore > 0`, run the time-based animation logic using `deltaTime` to incrementally move points from `state.atRiskScore` to the current player's banked score. Ignore all input during this stage.
         2.  **Wait for Dismissal:** Once `state.atRiskScore == 0`, the animation is complete. The game persists in this state and waits for `action != NONE`. This allows players to review the final score.
         3.  **Finalize Turn:** Once a button is pressed:

--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -87,6 +87,8 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_BankingPhase_ZeroFloorSafety`:** Verifies that `atRiskScore` does not go negative when the points to be moved in one loop are greater than the remaining `atRiskScore`.
     *   **`test_BankingPhase_InputSpamming`:** Verifies that button presses are ignored while the banking animation is in progress.
     *   **`test_BankingPhase_ManualAdvance`:** Verifies that a button press transitions to the `WaitingPhase` after the banking animation is complete.
+    *   **`test_BankingPhase_FarkleResetOnEnter`:** Verifies that the player's consecutive farkle count is reset to 0 immediately upon entering the `BankingPhase`.
+    *   **`test_BankingPhase_LightsOffDuringAnimation`:** Verifies that the `FarkleWarningLights` are off during the banking animation as a result of the farkle count reset.
 
 *   **`test_FarklingPhase.cpp`**
     *   **`test_FarklingPhase_AnimationMath`:** Verifies that the `atRiskScore` drains to 0 but does NOT add to player score.

--- a/src/farkle/src/phases/BankingPhase.cpp
+++ b/src/farkle/src/phases/BankingPhase.cpp
@@ -6,6 +6,7 @@ const float SCORE_ANIMATION_SPEED = 0.5f; // points per millisecond (approx 500 
 
 void BankingPhase::onEnter(GameState& state) {
     scoreMoveAccumulator = 0.0f;
+    state.players[state.currentPlayerIndex].farkle_count = 0;
 }
 
 GamePhase* BankingPhase::update(Game& game, GameState& state, ButtonAction action, unsigned long deltaTime) {
@@ -32,9 +33,6 @@ GamePhase* BankingPhase::update(Game& game, GameState& state, ButtonAction actio
 
         // Wait for user dismissal (any button press)
         if (action != ButtonAction::NONE) {
-            // Reset farkle count on a successful bank
-            state.players[state.currentPlayerIndex].farkle_count = 0;
-
             // Check for Final Round Trigger
             if (!state.finalRoundTriggered && state.players[state.currentPlayerIndex].score >= state.targetScore) {
                 state.finalRoundTriggered = true;

--- a/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.cpp
@@ -65,9 +65,40 @@ void test_BankingPhase_ManualAdvance() {
     TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
 }
 
+// Verifies that the farkle count is reset immediately upon entering the BankingPhase.
+void test_BankingPhase_FarkleResetOnEnter() {
+    Game game;
+    game.setup();
+    game.state.players[0].farkle_count = 2;
+
+    // Explicitly enter the phase
+    game.getPhase<BankingPhase>()->onEnter(game.state);
+
+    TEST_ASSERT_EQUAL_INT(0, game.state.players[0].farkle_count);
+}
+
+// Verifies that the farkle warning lights are off during the banking animation.
+void test_BankingPhase_LightsOffDuringAnimation() {
+    Game game;
+    game.setup();
+    game.state.players[0].farkle_count = 2;
+    game.currentPhase = game.getPhase<BankingPhase>();
+
+    // Enter the phase and update display
+    game.currentPhase->onEnter(game.state);
+
+    Displays displays(game.scoreDisplay, game.grid, game.farkleLights, game.oled);
+    game.currentPhase->display(game.state, displays);
+
+    // Captured state 0 means all lights are off
+    TEST_ASSERT_EQUAL_INT(0, game.farkleLights.captured_state);
+}
+
 void run_banking_phase_tests() {
     RUN_TEST(test_BankingPhase_AnimationMath);
     RUN_TEST(test_BankingPhase_ZeroFloorSafety);
     RUN_TEST(test_BankingPhase_InputSpamming);
     RUN_TEST(test_BankingPhase_ManualAdvance);
+    RUN_TEST(test_BankingPhase_FarkleResetOnEnter);
+    RUN_TEST(test_BankingPhase_LightsOffDuringAnimation);
 }

--- a/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.h
+++ b/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.h
@@ -5,6 +5,8 @@ void test_BankingPhase_AnimationMath();
 void test_BankingPhase_ZeroFloorSafety();
 void test_BankingPhase_InputSpamming();
 void test_BankingPhase_ManualAdvance();
+void test_BankingPhase_FarkleResetOnEnter();
+void test_BankingPhase_LightsOffDuringAnimation();
 void run_banking_phase_tests();
 
 #endif // TEST_BANKING_PHASE_H


### PR DESCRIPTION
The Farkle count is now reset immediately upon entering the `BankingPhase` via its `onEnter` method. This ensures that the `FarkleWarningLights` (which reflect the current player's farkle count) are turned off immediately when the banking animation begins, rather than persisting until the player dismisses the banking screen.

The change includes:
1.  Logic update in `BankingPhase.cpp`.
2.  Documentation updates in `GENERAL_GAME_PLAY.md`, `TECHNICAL_DESIGN_GAME_STATE_MACHINE.md`, and `TESTING_STRATEGY.md`.
3.  New unit tests in `test_BankingPhase.cpp` verifying the state reset and visual state of the lights.
4.  Verification that all 24 native test cases pass.

Fixes #35

---
*PR created automatically by Jules for task [9439750208864142082](https://jules.google.com/task/9439750208864142082) started by @gwenrich136*