### PR TITLE
Add Blinking Capability to ScoreDisplay

### DIFF
--- a/design/COMPONENT_LIBRARIES.md
+++ b/design/COMPONENT_LIBRARIES.md
@@ -98,16 +98,18 @@ The `ScoreDisplay` component controls three 5-digit 7-segment displays (driven b
 
 ### API Design
 -   **`ScoreDisplay(int dataPin, int clkPin, int csPin)`**: Constructor. Initializes the `LedControl` library with the appropriate pins for DIN, CLK, and CS, and performs basic setup for the three MAX7219 devices (wake up, set intensity, clear display).
--   **`void print_number(int number, int deviceIndex)`**: Displays an integer `number` on the specified `deviceIndex` (0, 1, or 2).
+-   **`void print_number(int number, int deviceIndex, bool blink = false)`**: Displays an integer `number` on the specified `deviceIndex` (0, 1, or 2).
     -   The number will be right-aligned on the 5-digit display.
+    -   If `blink` is `true`, the display's intensity will alternate between LOW (4) and HIGH (10) periodically.
 
 ### Key Logic & Behavior
 -   **Three Dedicated Displays:** The component provides three independent 5-digit displays, intended for:
     1.  `current_at_risk_score`
     2.  `current_player_banked_score`
     3.  `leading_score`
--   **Score Overflow Handling (Desired):** If the input `number` exceeds 99,999, the display should show `99999`. (The current implementation will be updated to reflect this desired behavior.)
--   **Readability-Focused Implementation:** The digit extraction and formatting are implemented using `std::string` for readability, with negligible performance impact on the target hardware.
+-   **Score Overflow Handling:** If the input `number` exceeds 99,999, the display will show `99999`.
+-   **Blinking Capability:** When enabled via `print_number`, the component uses `millis()` to toggle the device's intensity between two levels (4 and 10 on a 0-15 scale) every 500ms. This is non-blocking and relies on `print_number` being called frequently in the main game loop to update the intensity state.
+-   **Memory-Efficient Implementation:** The digit extraction and formatting are implemented using stack-allocated character buffers and integer arithmetic to avoid dynamic memory allocation and `std::string` overhead on the embedded target.
 
 ---
 

--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -155,3 +155,7 @@ pio test -e component_tests
 ### 6.4 Directory Structure
 *   `test/test_component_tests/`: Contains the test suites for components (e.g., `test_score_display.cpp`).
 *   `test/mocks/libs/`: Contains mocks for external libraries (e.g., `LedControl.h`, `FastLED.h`) used by components.
+
+### 6.5 Example Test Cases: `ScoreDisplay`
+*   **`test_ScoreDisplay_Correctness_Overflow`**: Verifies that numbers greater than 99,999 are capped and displayed as "99999".
+*   **`test_ScoreDisplay_Blinking_Intensity`**: Verifies that when `blink` is enabled, calling `print_number` (which should be called every frame) results in the intensity toggling between `SCORE_BLINK_LOW` (4) and `SCORE_BLINK_HIGH` (10) as time advances.

--- a/src/farkle/lib/components/ScoreDisplay/ScoreDisplay.cpp
+++ b/src/farkle/lib/components/ScoreDisplay/ScoreDisplay.cpp
@@ -5,6 +5,10 @@
 #define NUM_DIGITS_PER_DISPLAY 5
 #define TEN_THOUSAND 10000
 
+#define SCORE_BLINK_LOW 4
+#define SCORE_BLINK_HIGH 10
+#define SCORE_DEFAULT_INTENSITY 8
+
 ScoreDisplay::ScoreDisplay(int dataPin, int clkPin, int csPin)
   : _lc(dataPin, clkPin, csPin, NUM_DEVICES)
 {
@@ -14,15 +18,25 @@ void ScoreDisplay::begin() {
   // Set up the MAX7219 devices
   for (int i = 0; i < NUM_DEVICES; i++) {
     _lc.shutdown(i, false); // Wake up display
-    _lc.setIntensity(i, 8); // Set brightness (0-15)
+    _lc.setIntensity(i, SCORE_DEFAULT_INTENSITY); // Set brightness (0-15)
     _lc.clearDisplay(i);    // Clear display
   }
 }
 
 
-void ScoreDisplay::print_number(int number, int deviceIndex)
+void ScoreDisplay::print_number(int number, int deviceIndex, bool blink)
 {
-  int numberToDisplay = number % 100000;
+  int numberToDisplay = number;
+  if (numberToDisplay > 99999) {
+    numberToDisplay = 99999;
+  }
+
+  if (blink) {
+    int intensity = (millis() / 500) % 2 == 0 ? SCORE_BLINK_LOW : SCORE_BLINK_HIGH;
+    _lc.setIntensity(deviceIndex, intensity);
+  } else {
+    _lc.setIntensity(deviceIndex, SCORE_DEFAULT_INTENSITY);
+  }
 
   char digits[12];
   int len = 0;

--- a/src/farkle/lib/components/ScoreDisplay/ScoreDisplay.h
+++ b/src/farkle/lib/components/ScoreDisplay/ScoreDisplay.h
@@ -9,7 +9,7 @@ public:
   // dataPin, clkPin, csPin
   ScoreDisplay(int dataPin, int clkPin, int csPin);
   void begin();
-  void print_number(int number, int device_index);
+  void print_number(int number, int device_index, bool blink = false);
 
 private:
   LedControl _lc;

--- a/src/farkle/test/mocks/include/ScoreDisplay.h
+++ b/src/farkle/test/mocks/include/ScoreDisplay.h
@@ -6,10 +6,11 @@
 class ScoreDisplay {
 public:
     std::map<int, int> captured_numbers;
+    std::map<int, bool> captured_blinks;
 
     ScoreDisplay(int dataPin, int clkPin, int csPin);
     void begin();
-    void print_number(int number, int device_index);
+    void print_number(int number, int device_index, bool blink = false);
 };
 
 #endif // MOCK_SCORE_DISPLAY_H

--- a/src/farkle/test/mocks/libs/LedControl.h
+++ b/src/farkle/test/mocks/libs/LedControl.h
@@ -8,6 +8,8 @@
 // Global state for verification
 // Map<DeviceIndex, Map<DigitIndex, Character>>
 extern std::map<int, std::map<int, char>> mockLedState;
+// Map<DeviceIndex, Intensity>
+extern std::map<int, int> mockLedIntensity;
 
 class LedControl {
 public:
@@ -16,7 +18,9 @@ public:
 
     void shutdown(int addr, bool b) {}
 
-    void setIntensity(int addr, int intensity) {}
+    void setIntensity(int addr, int intensity) {
+        mockLedIntensity[addr] = intensity;
+    }
 
     void clearDisplay(int addr) {
         mockLedState[addr].clear();

--- a/src/farkle/test/mocks/src/ScoreDisplay.cpp
+++ b/src/farkle/test/mocks/src/ScoreDisplay.cpp
@@ -8,6 +8,7 @@ void ScoreDisplay::begin() {
     // Begin can be empty for the mock
 }
 
-void ScoreDisplay::print_number(int number, int device_index) {
+void ScoreDisplay::print_number(int number, int device_index, bool blink) {
     captured_numbers[device_index] = number;
+    captured_blinks[device_index] = blink;
 }

--- a/src/farkle/test/test_component_tests/test_score_display.cpp
+++ b/src/farkle/test/test_component_tests/test_score_display.cpp
@@ -6,11 +6,13 @@
 
 // Define the global mock state
 std::map<int, std::map<int, char>> mockLedState;
+std::map<int, int> mockLedIntensity;
 
 ScoreDisplay* display;
 
 void setUp(void) {
     mockLedState.clear();
+    mockLedIntensity.clear();
     // Pins don't matter for mock
     display = new ScoreDisplay(10, 11, 12);
     display->begin();
@@ -55,14 +57,36 @@ void test_ScoreDisplay_Correctness_Full(void) {
 }
 
 void test_ScoreDisplay_Correctness_Overflow(void) {
-    // Current implementation: number % 100000
-    // 100001 -> 1
+    // Should cap at 99999
     display->print_number(100001, 0);
-    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][0]);
-    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][1]);
-    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][2]);
-    TEST_ASSERT_EQUAL_CHAR(' ', mockLedState[0][3]);
-    TEST_ASSERT_EQUAL_CHAR('1', mockLedState[0][4]);
+    TEST_ASSERT_EQUAL_CHAR('9', mockLedState[0][0]);
+    TEST_ASSERT_EQUAL_CHAR('9', mockLedState[0][1]);
+    TEST_ASSERT_EQUAL_CHAR('9', mockLedState[0][2]);
+    TEST_ASSERT_EQUAL_CHAR('9', mockLedState[0][3]);
+    TEST_ASSERT_EQUAL_CHAR('9', mockLedState[0][4]);
+}
+
+void test_ScoreDisplay_Blinking_Intensity(void) {
+    // Assuming millis starts at 0
+    // 0 ms -> (0 / 500) % 2 == 0 -> SCORE_BLINK_LOW (4)
+    display->print_number(123, 0, true);
+    TEST_ASSERT_EQUAL_INT(4, mockLedIntensity[0]);
+
+    // Advance to 500ms
+    // 500 ms -> (500 / 500) % 2 == 1 -> SCORE_BLINK_HIGH (10)
+    advance_millis(500);
+    display->print_number(123, 0, true);
+    TEST_ASSERT_EQUAL_INT(10, mockLedIntensity[0]);
+
+    // Advance to 1000ms
+    // 1000 ms -> (1000 / 500) % 2 == 0 -> SCORE_BLINK_LOW (4)
+    advance_millis(500);
+    display->print_number(123, 0, true);
+    TEST_ASSERT_EQUAL_INT(4, mockLedIntensity[0]);
+
+    // Turn off blinking
+    display->print_number(123, 0, false);
+    TEST_ASSERT_EQUAL_INT(8, mockLedIntensity[0]);
 }
 
 void test_ScoreDisplay_Performance(void) {
@@ -89,6 +113,7 @@ int main(void) {
     RUN_TEST(test_ScoreDisplay_Correctness_Number);
     RUN_TEST(test_ScoreDisplay_Correctness_Full);
     RUN_TEST(test_ScoreDisplay_Correctness_Overflow);
+    RUN_TEST(test_ScoreDisplay_Blinking_Intensity);
     RUN_TEST(test_ScoreDisplay_Performance);
     return UNITY_END();
 }


### PR DESCRIPTION
This PR adds the requested blinking capability to the `ScoreDisplay` component. It also fixes the overflow behavior to cap at 99,999 instead of using modulo, aligning with the project's design goals. Relevant documentation and tests have been updated/added to ensure the new features work as expected and are well-documented.

Fixes #42

---
*PR created automatically by Jules for task [16310966123951586972](https://jules.google.com/task/16310966123951586972) started by @gwenrich136*