### PR TITLE
Update LedProgressGrid brightness polynomial

### DIFF
--- a/design/COMPONENT_LIBRARIES.md
+++ b/design/COMPONENT_LIBRARIES.md
@@ -86,7 +86,7 @@ The `LedProgressGrid` component manages an 8x8 NeoPixel grid to display player s
     -   **5-8 Players:** Each player gets one row, starting with Player 1 at row 0.
 -   **Snaking Pixel Layout:** The underlying NeoPixel hardware is assumed to be wired in a snaking pattern, which is handled by the `get_pixel_index` helper.
 -   **Internal `maxScore` Calculation:** The `update` method calculates the effective `maxScore` for display scaling based on game rules (multiples of 2000, min 10000).
--   **Non-Linear Brightness (Gamma Correction):** To align with human visual perception, the "remainder" pixel (the partially lit LED at the end of a bar) uses a squared brightness curve ($brightness = remainder^2 \times max\_brightness$). This ensures that small increases at the low end of the scale (0-10%) result in smaller visual changes than linear increases, preventing the "jumpy" look of linear PWM.
+-   **Non-Linear Brightness (Gamma Correction):** To align with human visual perception, the "remainder" pixel (the partially lit LED at the end of a bar) uses a 4th-degree polynomial brightness curve ($brightness = (2.7x^4 - 3.15x^3 + 1.2x^2 + 0.25x) \times max\_brightness$). This curve ($y'(0)=0.25$, $y'(1)=4$) ensures a slow increase at the low end to allow distinguishing small values, while ramping up significantly at the high end to account for the fact that a noticeable difference requires a larger absolute change when brightness is already high.
 -   **Blinking:** Blinking effects for at-risk scores and pending players are handled internally, using `millis()` for timing.
 
 ---

--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
@@ -38,20 +38,29 @@ int LedProgressGrid::get_pixel_index(int row, int col) {
 }
 
 int LedProgressGrid::getRemainderBrightness(float remainder, int fullBrightness) {
-  // The following is a cubic expression in terms of it's derrivate at 
-  // x=0 and x=1, denoted by y'(0) and y'(1), with the following constraints
+  // We use a 4th degree polynomial to map the linear remainder (0..1) to a
+  // brightness scale (0..1) that is more perceptually distinct.
+  //
+  // The polynomial was chosen with the following properties:
   //   - y(0) = 0
   //   - y(1) = 1
-  // 
-  // y(x) = (y'(1) - y'(0) - 2) * x^3 
-  //        + (3 - y'(1) - 2 * y'(0)) * x^2 
-  //        + y'(0) * x
+  //   - y'(0) = 0.25 (Slope at start)
+  //   - y'(1) = 4.0  (Slope at end)
   //
-  // With a desired y'(0) of 1/3 and y'(1) of 3, we get:
-  //   - y(x) = (4/3) x^3 - (2/3) x^2 + (1/3) x
+  // This gives us a curve that increases slowly at first (allowing distinguishing
+  // low values) and ramps up significantly at the end.
+  //
+  // The polynomial is:
+  // y(x) = 2.7x^4 - 3.15x^3 + 1.2x^2 + 0.25x
+
   float x = remainder;
-  float y = (4*x*x - 2*x + 1) * x / 3.0;
-  return (int) fullBrightness * y;
+  float x2 = x * x;
+  float x3 = x2 * x;
+  float x4 = x3 * x;
+
+  float y = (2.7f * x4) - (3.15f * x3) + (1.2f * x2) + (0.25f * x);
+
+  return (int) (fullBrightness * y);
 }
 
 int LedProgressGrid::addPlayer() {


### PR DESCRIPTION
This change updates the `LedProgressGrid` component to use a new 4th-degree polynomial for the remainder brightness calculation. The new polynomial provides a brightness curve that increases slowly at low values (slope 0.25) and ramps up significantly at high values (slope 4.0), which improves visual distinction for human perception. The implementation is optimized to avoid repeated multiplications. Documentation has been updated to match the code.

---
*PR created automatically by Jules for task [14564282940593154236](https://jules.google.com/task/14564282940593154236) started by @gwenrich136*