### PR TITLE
🔒 Fix OOB Write in ControlPad::addButton

### DIFF
--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -166,3 +166,8 @@ pio test -e component_tests
 ### 6.5 Example Test Cases: `ScoreDisplay`
 *   **`test_ScoreDisplay_Correctness_Overflow`**: Verifies that numbers greater than 99,999 are capped and displayed as "99999".
 *   **`test_ScoreDisplay_Blinking_Intensity`**: Verifies that when `blink` is enabled, calling `print_number` (which should be called every frame) results in the intensity toggling between `SCORE_BLINK_LOW` (2) and `SCORE_BLINK_HIGH` (12) as time advances.
+
+### 6.6 Example Test Cases: `ControlPad`
+*   **`test_add_valid_button`**: Verifies that adding a button with a valid pin correctly configures the pin mode to `INPUT_PULLUP`.
+*   **`test_add_invalid_pin_negative`**: Verifies that adding a button with a negative pin index is ignored and does not corrupt memory or configure hardware.
+*   **`test_read_valid_button`**: Verifies that reading the control pad correctly detects a button press (LOW state) and returns the associated action.

--- a/src/farkle/lib/components/ControlPad/ControlPad.cpp
+++ b/src/farkle/lib/components/ControlPad/ControlPad.cpp
@@ -9,7 +9,7 @@ ControlPad::ControlPad() : _lastAction(ButtonAction::NONE) {
 }
 
 void ControlPad::addButton(int pin, ButtonAction buttonAction) {
-  if (pin < MAX_PINS) {
+  if (pin >= 0 && pin < MAX_PINS) {
     _buttonMap[pin] = buttonAction;
     pinMode(pin, INPUT_PULLUP); // Configure pin as input with pull-up resistor
   }

--- a/src/farkle/platformio.ini
+++ b/src/farkle/platformio.ini
@@ -39,7 +39,8 @@ build_flags =
   -Iinclude
   -Ilib/components/ScoreDisplay
   -Ilib/components/LedProgressGrid
+  -Ilib/components/ControlPad
   -Itest/mocks/include
   -Itest/mocks/libs
   -DUNIT_TEST
-build_src_filter = +<*> -<main.cpp> +<../test/mocks/src/> -<../test/mocks/src/ScoreDisplay.cpp> +<../lib/components/ScoreDisplay/ScoreDisplay.cpp> -<../test/mocks/src/LedProgressGrid.cpp> +<../lib/components/LedProgressGrid/LedProgressGrid.cpp>
+build_src_filter = +<*> -<main.cpp> +<../test/mocks/src/> -<../test/mocks/src/ScoreDisplay.cpp> +<../lib/components/ScoreDisplay/ScoreDisplay.cpp> -<../test/mocks/src/LedProgressGrid.cpp> +<../lib/components/LedProgressGrid/LedProgressGrid.cpp> -<../test/mocks/src/ControlPad.cpp> +<../lib/components/ControlPad/ControlPad.cpp>

--- a/src/farkle/test/mocks/include/Arduino.h
+++ b/src/farkle/test/mocks/include/Arduino.h
@@ -12,10 +12,27 @@ const int A0 = 0;
 const int A1 = 1;
 const int A2 = 2;
 
+// Pin modes
+const int INPUT = 0;
+const int OUTPUT = 1;
+const int INPUT_PULLUP = 2;
+
+// Pin levels
+const int LOW = 0;
+const int HIGH = 1;
+
 // Mock Arduino functions
 unsigned long millis();
 void delay(unsigned long ms);
 void advance_millis(unsigned long ms);
+
+void pinMode(int pin, int mode);
+int digitalRead(int pin);
+
+// Test helpers
+void setMockPinState(int pin, int state);
+int getMockPinMode(int pin);
+void resetMockPins();
 
 long random(long max);
 long random(long min, long max);

--- a/src/farkle/test/mocks/src/Arduino.cpp
+++ b/src/farkle/test/mocks/src/Arduino.cpp
@@ -1,7 +1,10 @@
 #include "Arduino.h"
 #include <cstdlib>
+#include <map>
 
 static unsigned long mocked_millis = 0;
+static std::map<int, int> mockPinModes;
+static std::map<int, int> mockPinStates;
 
 unsigned long millis() {
     return mocked_millis;
@@ -13,6 +16,33 @@ void delay(unsigned long ms) {
 
 void advance_millis(unsigned long ms) {
     mocked_millis += ms;
+}
+
+void pinMode(int pin, int mode) {
+    mockPinModes[pin] = mode;
+}
+
+int digitalRead(int pin) {
+    if (mockPinStates.find(pin) == mockPinStates.end()) {
+        return HIGH; // Default to HIGH (like INPUT_PULLUP unpressed)
+    }
+    return mockPinStates[pin];
+}
+
+void setMockPinState(int pin, int state) {
+    mockPinStates[pin] = state;
+}
+
+int getMockPinMode(int pin) {
+    if (mockPinModes.find(pin) == mockPinModes.end()) {
+        return -1; // -1 for undefined/default
+    }
+    return mockPinModes[pin];
+}
+
+void resetMockPins() {
+    mockPinModes.clear();
+    mockPinStates.clear();
 }
 
 long random(long max) {

--- a/src/farkle/test/test_component_control_pad/test_control_pad.cpp
+++ b/src/farkle/test/test_component_control_pad/test_control_pad.cpp
@@ -1,0 +1,71 @@
+#include <unity.h>
+#include "ControlPad.h"
+#include "Arduino.h"
+#include "ButtonActions.h"
+
+ControlPad* controlPad;
+
+void setUp(void) {
+    controlPad = new ControlPad();
+    resetMockPins();
+}
+
+void tearDown(void) {
+    delete controlPad;
+}
+
+void test_add_valid_button(void) {
+    int pin = 2;
+    ButtonAction action = ButtonAction::BANK;
+
+    controlPad->addButton(pin, action);
+
+    // Verify pinMode was called with INPUT_PULLUP
+    TEST_ASSERT_EQUAL_INT(INPUT_PULLUP, getMockPinMode(pin));
+}
+
+void test_add_invalid_pin_negative(void) {
+    int pin = -1;
+    ButtonAction action = ButtonAction::BANK;
+
+    controlPad->addButton(pin, action);
+
+    // Verify pinMode was NOT called for this pin
+    TEST_ASSERT_EQUAL_INT(-1, getMockPinMode(pin));
+}
+
+void test_add_invalid_pin_too_large(void) {
+    int pin = 17; // MAX_PINS is 17, so 17 is OOB (0-16 are valid if MAX_PINS was size, but code says MAX_PINS is 17 and array is size 17, so indices 0..16)
+    // Wait, let me check ControlPad.h
+    // #define MAX_PINS 17
+    // ButtonAction _buttonMap[MAX_PINS];
+    // So indices 0 to 16 are valid. 17 is OOB.
+
+    ButtonAction action = ButtonAction::BANK;
+
+    controlPad->addButton(pin, action);
+
+    // Verify pinMode was NOT called for this pin
+    TEST_ASSERT_EQUAL_INT(-1, getMockPinMode(pin));
+}
+
+void test_read_valid_button(void) {
+    int pin = 5;
+    ButtonAction action = ButtonAction::CLEAR;
+
+    controlPad->addButton(pin, action);
+
+    // Simulate button press (LOW)
+    setMockPinState(pin, LOW);
+
+    TEST_ASSERT_EQUAL(action, controlPad->read());
+}
+
+int main(int argc, char **argv) {
+    UNITY_BEGIN();
+    RUN_TEST(test_add_valid_button);
+    RUN_TEST(test_add_invalid_pin_negative);
+    RUN_TEST(test_add_invalid_pin_too_large);
+    RUN_TEST(test_read_valid_button);
+    return UNITY_END();
+}


### PR DESCRIPTION
🎯 **What:** Fixed an "Out-of-bounds Write" vulnerability in `ControlPad::addButton`.
⚠️ **Risk:** If a negative pin number was passed to `addButton`, it would write to `_buttonMap` with a negative index, corrupting heap memory and potentially causing crashes or unpredictable behavior.
🛡️ **Solution:** Added a check `if (pin >= 0 && pin < MAX_PINS)` before accessing the array.

Also added comprehensive unit tests for `ControlPad` and enhanced the `Arduino` mock to support pin operations.

---
*PR created automatically by Jules for task [15378230925458804157](https://jules.google.com/task/15378230925458804157) started by @gwenrich136*