### PR TITLE
Implement Pre-Game Player Selection Phase

### DIFF
--- a/src/farkle/include/Game.h
+++ b/src/farkle/include/Game.h
@@ -7,6 +7,7 @@
 #include "GamePhase.h"
 #include <type_traits>
 
+#include "phases/PlayerSelectionPhase.h"
 #include "phases/WaitingPhase.h"
 #include "phases/BankingPhase.h"
 #include "phases/FarklingPhase.h"
@@ -29,6 +30,7 @@ public:
     // Templated helper to get a pointer to a specific phase from the pool
     template<typename T>
     T* getPhase() {
+        if (std::is_same<T, PlayerSelectionPhase>::value) return (T*)&phasePool.playerSelection;
         if (std::is_same<T, WaitingPhase>::value) return (T*)&phasePool.waiting;
         if (std::is_same<T, BankingPhase>::value) return (T*)&phasePool.banking;
         if (std::is_same<T, FarklingPhase>::value) return (T*)&phasePool.farkling;
@@ -37,12 +39,17 @@ public:
         return nullptr;
     }
 
+    void addPlayer(const std::string& name);
+    void resetGame();
+    bool canAddPlayer() const;
+
 #ifdef UNIT_TEST
 public:
 #else
 private:
 #endif
     struct PhasePool {
+        PlayerSelectionPhase playerSelection;
         WaitingPhase waiting;
         BankingPhase banking;
         FarklingPhase farkling;

--- a/src/farkle/include/GameState.h
+++ b/src/farkle/include/GameState.h
@@ -21,6 +21,14 @@ struct GameState {
     int targetScore;
 
     GameState() : atRiskScore(0), currentPlayerIndex(0), finalRoundTriggered(false), targetScore(10000) {}
+
+    void reset() {
+        players.clear();
+        atRiskScore = 0;
+        currentPlayerIndex = 0;
+        finalRoundTriggered = false;
+        targetScore = 10000;
+    }
 };
 
 #endif

--- a/src/farkle/include/phases/PlayerSelectionPhase.h
+++ b/src/farkle/include/phases/PlayerSelectionPhase.h
@@ -1,0 +1,21 @@
+#ifndef PlayerSelectionPhase_h
+#define PlayerSelectionPhase_h
+
+#include "GamePhase.h"
+#include <vector>
+#include <string>
+
+class PlayerSelectionPhase : public GamePhase {
+public:
+    PlayerSelectionPhase();
+    virtual void onEnter(GameState& state) override;
+    virtual GamePhase* update(Game& game, GameState& state, ButtonAction action, unsigned long deltaTime) override;
+    virtual void display(const GameState& state, const Displays& displays) override;
+
+private:
+    int m_selectionIndex;
+    std::vector<std::string> m_namePool;
+    std::vector<std::string> getFilteredNames(const GameState& state);
+};
+
+#endif

--- a/src/farkle/src/Game.cpp
+++ b/src/farkle/src/Game.cpp
@@ -42,23 +42,11 @@ void Game::setup() {
     controlPad.addButton(7, CLEAR);
     controlPad.addButton(8, FARKLE);
 
-    // 2. Initialize Game State with 4 hardcoded players for V1
-    state.players.push_back(Player("PLAYER 1"));
-    state.players.push_back(Player("PLAYER 2"));
-    state.players.push_back(Player("PLAYER 3"));
-    state.players.push_back(Player("PLAYER 4"));
-
-    // Add players to the grid to assign them colors
-    for (int i = 0; i < 4; ++i) {
-        grid.addPlayer();
-    }
-
-    state.currentPlayerIndex = 0;
-    state.atRiskScore = 0;
-    state.finalRoundTriggered = false;
+    // 2. Initialize Game State
+    resetGame();
 
     // 3. Set Initial State
-    currentPhase = &phasePool.waiting;
+    currentPhase = &phasePool.playerSelection;
     currentPhase->onEnter(state);
     
     lastUpdateTime = millis();
@@ -87,4 +75,19 @@ void Game::loop() {
 
     // 6. Display Current State
     currentPhase->display(state, displays);
+}
+
+void Game::addPlayer(const std::string& name) {
+    state.players.push_back(Player(name));
+    grid.addPlayer();
+}
+
+void Game::resetGame() {
+    state.reset();
+    grid.reset();
+}
+
+bool Game::canAddPlayer() const {
+    // We need to cast away const because LedProgressGrid::isMaxPlayersReached is not const
+    return !const_cast<LedProgressGrid&>(grid).isMaxPlayersReached();
 }

--- a/src/farkle/src/phases/PlayerSelectionPhase.cpp
+++ b/src/farkle/src/phases/PlayerSelectionPhase.cpp
@@ -1,0 +1,67 @@
+#include "phases/PlayerSelectionPhase.h"
+#include "Game.h"
+#include "phases/WaitingPhase.h"
+#include <algorithm>
+
+PlayerSelectionPhase::PlayerSelectionPhase() : m_selectionIndex(0) {
+    m_namePool = {"Geewee", "Sammy", "Coach", "Sheshe", "Alex", "Tigre", "Pepa", "Fred", "Andrea"};
+}
+
+void PlayerSelectionPhase::onEnter(GameState& state) {
+    m_selectionIndex = 0;
+}
+
+std::vector<std::string> PlayerSelectionPhase::getFilteredNames(const GameState& state) {
+    std::vector<std::string> filtered;
+    for (const auto& name : m_namePool) {
+        bool alreadyAdded = false;
+        for (const auto& player : state.players) {
+            if (player.name == name) {
+                alreadyAdded = true;
+                break;
+            }
+        }
+        if (!alreadyAdded) {
+            filtered.push_back(name);
+        }
+    }
+    return filtered;
+}
+
+GamePhase* PlayerSelectionPhase::update(Game& game, GameState& state, ButtonAction action, unsigned long deltaTime) {
+    auto filteredNames = getFilteredNames(state);
+
+    if (action == ButtonAction::UP_1000) {
+        if (!filteredNames.empty()) {
+            m_selectionIndex = (m_selectionIndex + 1) % filteredNames.size();
+        }
+    } else if (action == ButtonAction::DOWN_50) {
+        if (!filteredNames.empty()) {
+            m_selectionIndex = (m_selectionIndex - 1 + filteredNames.size()) % filteredNames.size();
+        }
+    } else if (action == ButtonAction::BANK) {
+        if (!filteredNames.empty() && game.canAddPlayer()) {
+            game.addPlayer(filteredNames[m_selectionIndex]);
+            m_selectionIndex = 0; // Reset selection index after adding
+        }
+    } else if (action == ButtonAction::FARKLE) {
+        if (state.players.size() >= 1) {
+            return game.getPhase<WaitingPhase>();
+        }
+    }
+
+    return this;
+}
+
+void PlayerSelectionPhase::display(const GameState& state, const Displays& displays) {
+    auto filteredNames = getFilteredNames(state);
+    const char* currentSelection = filteredNames.empty() ? "MAX PLAYERS" : filteredNames[m_selectionIndex].c_str();
+
+    displays.oled.printSelectionScreen("Add Player", currentSelection);
+    displays.grid.displayPlayersPregame(!displays.grid.isMaxPlayersReached());
+
+    displays.scoreDisplay.clear(ScoreDisplay::DisplayType::AT_RISK_SCORE);
+    displays.scoreDisplay.clear(ScoreDisplay::DisplayType::CURRENT_PLAYER_SCORE);
+    displays.scoreDisplay.clear(ScoreDisplay::DisplayType::COMPETITION_SCORE);
+    displays.farkleLights.farkle_state(0);
+}

--- a/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
+++ b/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
@@ -8,7 +8,7 @@
 // Simulates a full game where players take turns scoring until one player reaches the target score, triggering the final round.
 void test_FullGame_StandardGame() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     int turn = 0;
     while (game.currentPhase != game.getPhase<PostGamePhase_V1>() && turn < 100) {
@@ -35,7 +35,7 @@ void test_FullGame_StandardGame() {
 // Test function to verify the triple farkle penalty and reset behavior
 void test_FullGame_TripleFarkle() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.players[0].score = 2500; // Give player 1 some points
 
     // --- First Farkle ---
@@ -68,7 +68,7 @@ void test_FullGame_TripleFarkle() {
 
 void test_FullGame_TripleFarkle_ScoreLessThanPenalty() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     // --- Player 0 scores 500 points ---
     simulateButtonPress(game, ButtonAction::RIGHT_500);

--- a/src/farkle/test/test_game_logic/medium_tests/test_conditional_at_risk_display.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_conditional_at_risk_display.cpp
@@ -5,7 +5,7 @@
 
 void test_DisplayLogic_WaitingPhase_ShowsZero() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     // Ensure we are in WaitingPhase
     game.state.atRiskScore = 0;
@@ -18,7 +18,7 @@ void test_DisplayLogic_WaitingPhase_ShowsZero() {
 
 void test_DisplayLogic_BankingPhase_ClearsZero() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     // Enter BankingPhase
     game.state.atRiskScore = 100;
@@ -38,7 +38,7 @@ void test_DisplayLogic_BankingPhase_ClearsZero() {
 
 void test_DisplayLogic_PenaltyFarklingPhase_ClearsOnlyAtZero() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.players[0].farkle_count = 2;
     game.state.players[0].score = 1000;
 
@@ -75,7 +75,7 @@ void test_DisplayLogic_PenaltyFarklingPhase_ClearsOnlyAtZero() {
 
 void test_DisplayLogic_FarklingPhase_ClearsZero() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     // Enter FarklingPhase
     game.state.atRiskScore = 100;

--- a/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
@@ -7,7 +7,7 @@
 // Verifies that a standard turn correctly banks the score and advances to the next player.
 void test_TurnLifecycle_StandardTurn() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     simulateButtonPress(game, ButtonAction::UP_1000);
     simulateButtonPress(game, ButtonAction::RIGHT_500);
     
@@ -28,7 +28,7 @@ void test_TurnLifecycle_StandardTurn() {
 // Verifies that the game correctly cycles through all players.
 void test_TurnLifecycle_RoundRobin() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     for (int i = 0; i < 4; i++) {
         simulateButtonPress(game, ButtonAction::UP_1000);
@@ -49,7 +49,7 @@ void test_TurnLifecycle_RoundRobin() {
 // Verifies that the clear button resets the atRiskScore to 0.
 void test_TurnLifecycle_ClearButton() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     simulateButtonPress(game, ButtonAction::UP_1000);
     simulateButtonPress(game, ButtonAction::RIGHT_500);
     simulateButtonPress(game, ButtonAction::CLEAR);

--- a/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.cpp
@@ -9,7 +9,7 @@
 // Verifies that the score animation correctly moves points from atRiskScore to the player's score.
 void test_BankingPhase_AnimationMath() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 500;
     game.state.players[0].score = 0;
     game.currentPhase = game.getPhase<BankingPhase>();
@@ -25,7 +25,7 @@ void test_BankingPhase_AnimationMath() {
 // Verifies that atRiskScore does not go negative when the points to be moved in one loop are greater than the remaining atRiskScore.
 void test_BankingPhase_ZeroFloorSafety() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 50;
     game.state.players[0].score = 0;
     game.currentPhase = game.getPhase<BankingPhase>();
@@ -39,7 +39,7 @@ void test_BankingPhase_ZeroFloorSafety() {
 // Verifies that button presses are ignored while the banking animation is in progress.
 void test_BankingPhase_InputSpamming() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 500;
     game.currentPhase = game.getPhase<BankingPhase>();
 
@@ -53,7 +53,7 @@ void test_BankingPhase_InputSpamming() {
 // Verifies that a button press transitions to the WaitingPhase after the banking animation is complete.
 void test_BankingPhase_ManualAdvance() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 0;
     game.currentPhase = game.getPhase<BankingPhase>();
 
@@ -68,7 +68,7 @@ void test_BankingPhase_ManualAdvance() {
 // Verifies that the farkle count is reset immediately upon entering the BankingPhase.
 void test_BankingPhase_FarkleResetOnEnter() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.players[0].farkle_count = 2;
 
     // Explicitly enter the phase
@@ -80,7 +80,7 @@ void test_BankingPhase_FarkleResetOnEnter() {
 // Verifies that the farkle warning lights are off during the banking animation.
 void test_BankingPhase_LightsOffDuringAnimation() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.players[0].farkle_count = 2;
     game.currentPhase = game.getPhase<BankingPhase>();
 

--- a/src/farkle/test/test_game_logic/small_tests/test_FarklingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_FarklingPhase.cpp
@@ -9,7 +9,7 @@
 // Verifies that the atRiskScore drains to 0 but does NOT add to player score.
 void test_FarklingPhase_AnimationMath() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 500;
     game.state.players[0].score = 1000;
     game.currentPhase = game.getPhase<FarklingPhase>();
@@ -26,7 +26,7 @@ void test_FarklingPhase_AnimationMath() {
 // Verifies that atRiskScore does not go negative.
 void test_FarklingPhase_ZeroFloorSafety() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 50;
     game.currentPhase = game.getPhase<FarklingPhase>();
     game.currentPhase->onEnter(game.state);
@@ -39,7 +39,7 @@ void test_FarklingPhase_ZeroFloorSafety() {
 // Verifies that button presses are ignored while the farkling animation is in progress.
 void test_FarklingPhase_InputSpamming() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 500;
     game.currentPhase = game.getPhase<FarklingPhase>();
     game.currentPhase->onEnter(game.state);
@@ -54,7 +54,7 @@ void test_FarklingPhase_InputSpamming() {
 // Verifies that farkle_count does NOT increment if the player has 0 points.
 void test_FarklingPhase_NoHarmNoFoul_NoIncrement() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.players[0].score = 0;
     game.state.players[0].farkle_count = 0;
 
@@ -67,7 +67,7 @@ void test_FarklingPhase_NoHarmNoFoul_NoIncrement() {
 // Verifies that farkle_count DOES increment if the player has points.
 void test_FarklingPhase_IncrementWithPoints() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.players[0].score = 100;
     game.state.players[0].farkle_count = 0;
 
@@ -80,7 +80,7 @@ void test_FarklingPhase_IncrementWithPoints() {
 // Verifies that a button press transitions to the WaitingPhase after the animation is complete.
 void test_FarklingPhase_ManualAdvance() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 0;
     game.currentPhase = game.getPhase<FarklingPhase>();
     game.currentPhase->onEnter(game.state);

--- a/src/farkle/test/test_game_logic/small_tests/test_PenaltyFarklingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PenaltyFarklingPhase.cpp
@@ -10,7 +10,7 @@
 // and subtracts from the player's score, after the 3-second pause.
 void test_PenaltyFarklingPhase_AnimationMath() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.currentPhase = game.getPhase<PenaltyFarklingPhase>();
     game.currentPhase->onEnter(game.state);
     game.state.atRiskScore = -1000;
@@ -40,7 +40,7 @@ void test_PenaltyFarklingPhase_AnimationMath() {
 // Verifies that the blink parameter is correctly passed to the ScoreDisplay during THE_PAIN.
 void test_PenaltyFarklingPhase_BlinkParameter() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.players[0].score = 1000; // Ensure atRiskScore is non-zero
     game.currentPhase = game.getPhase<PenaltyFarklingPhase>();
     game.currentPhase->onEnter(game.state);
@@ -55,7 +55,7 @@ void test_PenaltyFarklingPhase_BlinkParameter() {
 // Verifies that atRiskScore does not go above 0 (Zero Ceiling).
 void test_PenaltyFarklingPhase_ZeroCeilingSafety() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.currentPhase = game.getPhase<PenaltyFarklingPhase>();
     game.currentPhase->onEnter(game.state);
     game.state.atRiskScore = -50;
@@ -73,7 +73,7 @@ void test_PenaltyFarklingPhase_ZeroCeilingSafety() {
 // Verifies that button presses are ignored while the animation is in progress.
 void test_PenaltyFarklingPhase_InputSpamming() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.currentPhase = game.getPhase<PenaltyFarklingPhase>();
     game.currentPhase->onEnter(game.state);
     game.state.atRiskScore = -500;
@@ -88,7 +88,7 @@ void test_PenaltyFarklingPhase_InputSpamming() {
 // Verifies that a button press transitions to the WaitingPhase after the animation is complete.
 void test_PenaltyFarklingPhase_ManualAdvance() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.currentPhase = game.getPhase<PenaltyFarklingPhase>();
     game.currentPhase->onEnter(game.state);
     game.state.atRiskScore = -100;

--- a/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
@@ -1,0 +1,87 @@
+#include "test_PlayerSelectionPhase.h"
+#include "Game.h"
+#include "phases/PlayerSelectionPhase.h"
+#include "phases/WaitingPhase.h"
+#include "../test_utils.h"
+#include <unity.h>
+
+void test_PlayerSelectionPhase_Navigation() {
+    Game game;
+    game.setup();
+
+    // Initial state should be PlayerSelectionPhase
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<PlayerSelectionPhase>(), game.currentPhase);
+
+    // Test navigation doesn't crash and stays in phase
+    simulateButtonPress(game, ButtonAction::UP_1000);
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<PlayerSelectionPhase>(), game.currentPhase);
+
+    simulateButtonPress(game, ButtonAction::DOWN_50);
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<PlayerSelectionPhase>(), game.currentPhase);
+}
+
+void test_PlayerSelectionPhase_AddPlayer() {
+    Game game;
+    game.setup();
+
+    TEST_ASSERT_EQUAL_INT(0, game.state.players.size());
+
+    // Press BANK to add Geewee
+    simulateButtonPress(game, ButtonAction::BANK);
+
+    TEST_ASSERT_EQUAL_INT(1, game.state.players.size());
+    TEST_ASSERT_EQUAL_STRING("Geewee", game.state.players[0].name.c_str());
+}
+
+void test_PlayerSelectionPhase_FilterDuplicateNames() {
+    Game game;
+    game.setup();
+
+    // Add Geewee
+    simulateButtonPress(game, ButtonAction::BANK);
+    TEST_ASSERT_EQUAL_INT(1, game.state.players.size());
+
+    // Press BANK again. Navigation should have moved to next name (Sammy) because Geewee is filtered
+    simulateButtonPress(game, ButtonAction::BANK);
+    TEST_ASSERT_EQUAL_INT(2, game.state.players.size());
+    TEST_ASSERT_EQUAL_STRING("Sammy", game.state.players[1].name.c_str());
+}
+
+void test_PlayerSelectionPhase_MaxPlayersLimit() {
+    Game game;
+    game.setup();
+
+    // Add 8 players (max)
+    for (int i = 0; i < 8; ++i) {
+        simulateButtonPress(game, ButtonAction::BANK);
+    }
+    TEST_ASSERT_EQUAL_INT(8, game.state.players.size());
+
+    // Try to add 9th
+    simulateButtonPress(game, ButtonAction::BANK);
+    TEST_ASSERT_EQUAL_INT(8, game.state.players.size());
+}
+
+void test_PlayerSelectionPhase_TransitionToWaiting() {
+    Game game;
+    game.setup();
+
+    // Try to start with 0 players
+    simulateButtonPress(game, ButtonAction::FARKLE);
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<PlayerSelectionPhase>(), game.currentPhase);
+
+    // Add 1 player
+    simulateButtonPress(game, ButtonAction::BANK);
+
+    // Try to start with 1 player
+    simulateButtonPress(game, ButtonAction::FARKLE);
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
+}
+
+void run_player_selection_phase_tests() {
+    RUN_TEST(test_PlayerSelectionPhase_Navigation);
+    RUN_TEST(test_PlayerSelectionPhase_AddPlayer);
+    RUN_TEST(test_PlayerSelectionPhase_FilterDuplicateNames);
+    RUN_TEST(test_PlayerSelectionPhase_MaxPlayersLimit);
+    RUN_TEST(test_PlayerSelectionPhase_TransitionToWaiting);
+}

--- a/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.h
+++ b/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.h
@@ -1,0 +1,12 @@
+#ifndef TEST_PLAYER_SELECTION_PHASE_H
+#define TEST_PLAYER_SELECTION_PHASE_H
+
+void test_PlayerSelectionPhase_Navigation();
+void test_PlayerSelectionPhase_AddPlayer();
+void test_PlayerSelectionPhase_FilterDuplicateNames();
+void test_PlayerSelectionPhase_MaxPlayersLimit();
+void test_PlayerSelectionPhase_TransitionToWaiting();
+
+void run_player_selection_phase_tests();
+
+#endif // TEST_PLAYER_SELECTION_PHASE_H

--- a/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.cpp
@@ -9,7 +9,7 @@
 // Verifies that the atRiskScore correctly accumulates when score buttons are pressed.
 void test_WaitingPhase_ScoreAccumulation() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     // Ensure atRiskScore is initially 0
     TEST_ASSERT_EQUAL_INT(0, game.state.atRiskScore);
@@ -25,7 +25,7 @@ void test_WaitingPhase_ScoreAccumulation() {
 // Verifies that the atRiskScore is cleared when the CLEAR button is pressed.
 void test_WaitingPhase_ScoreCorrection() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     // Add some score
     simulateButtonPress(game, ButtonAction::UP_1000);
@@ -41,7 +41,7 @@ void test_WaitingPhase_ScoreCorrection() {
 // Verifies that the game transitions to the BankingPhase when the BANK button is pressed.
 void test_WaitingPhase_TransitionToBanking() {
     Game game;
-    game.setup(); // Initialize the game
+    setupGameWithPlayers(game, 4);
 
     // Ensure initial state is WaitingPhase
     TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
@@ -59,7 +59,7 @@ void test_WaitingPhase_TransitionToBanking() {
 // Verifies that the game transitions to the FarklingPhase when the FARKLE button is pressed.
 void test_WaitingPhase_TransitionToFarkling() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
 
     // Ensure initial state is WaitingPhase
     TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
@@ -74,7 +74,7 @@ void test_WaitingPhase_TransitionToFarkling() {
 // Verifies that PenaltyFarklingPhase IS triggered if the player has 3 consecutive farkles.
 void test_WaitingPhase_TransitionToPenaltyFarkling() {
     Game game;
-    game.setup();
+    setupGameWithPlayers(game, 4);
     game.state.players[0].farkle_count = 2;
     game.state.players[0].score = 1000;
 

--- a/src/farkle/test/test_game_logic/test_main.cpp
+++ b/src/farkle/test/test_game_logic/test_main.cpp
@@ -1,4 +1,5 @@
 #include <unity.h>
+#include "small_tests/test_PlayerSelectionPhase.h"
 #include "small_tests/test_WaitingPhase.h"
 #include "small_tests/test_FarklingPhase.h"
 #include "small_tests/test_PenaltyFarklingPhase.h"
@@ -16,6 +17,7 @@ void tearDown(void) {
 }
 
 void test_runner() {
+    run_player_selection_phase_tests();
     run_waiting_phase_tests();
     run_farkling_phase_tests();
     run_penalty_farkling_phase_tests();

--- a/src/farkle/test/test_game_logic/test_utils.cpp
+++ b/src/farkle/test/test_game_logic/test_utils.cpp
@@ -7,6 +7,19 @@ void simulateButtonPress(Game& game, ButtonAction action, unsigned long advance_
     game.loop();
 }
 
+void setupGameWithPlayers(Game& game, int numPlayers) {
+    game.setup();
+    // Assuming we start in PlayerSelectionPhase
+    for (int i = 0; i < numPlayers; ++i) {
+        // Just add players directly for testing convenience, or simulate buttons
+        char name[20];
+        sprintf(name, "PLAYER %d", i + 1);
+        game.addPlayer(name);
+    }
+    // Transition to WaitingPhase
+    simulateButtonPress(game, ButtonAction::FARKLE);
+}
+
 void waitForScoreAnimation(Game& game) {
     while (game.state.atRiskScore != 0) {
         simulateNoAction(game);

--- a/src/farkle/test/test_game_logic/test_utils.h
+++ b/src/farkle/test/test_game_logic/test_utils.h
@@ -7,5 +7,6 @@
 void simulateButtonPress(Game& game, ButtonAction action, unsigned long advance_time_millis = 10);
 void simulateNoAction(Game& game, unsigned long advance_time_millis = 10);
 void waitForScoreAnimation(Game& game);
+void setupGameWithPlayers(Game& game, int numPlayers);
 
 #endif // TEST_UTILS_H


### PR DESCRIPTION
Implemented the PlayerSelectionPhase which allows users to dynamically build a roster of 1-8 players using the onboard physical controls.
The phase includes:
- A predefined name pool: Geewee, Sammy, Coach, Sheshe, Alex, Tigre, Pepa, Fred, and Andrea.
- Navigation using UP_1000 and DOWN_50 buttons.
- Filtering of already added names.
- Adding players with the BANK button (up to 8 players).
- Transitioning to the game with the FARKLE button (requires at least 1 player).

Updated the Game class and GameState to support this new phase and ensured all existing tests remain valid by providing a helper to bypass the selection phase during testing.

Fixes #69

---
*PR created automatically by Jules for task [126296383211571726](https://jules.google.com/task/126296383211571726) started by @gwenrich136*