### PR TITLE
Fix Button Bouncing in ControlPad

### DIFF
--- a/src/farkle/lib/components/ControlPad/ControlPad.cpp
+++ b/src/farkle/lib/components/ControlPad/ControlPad.cpp
@@ -5,6 +5,9 @@ ControlPad::ControlPad() : _lastAction(ButtonAction::NONE), _activePinCount(0) {
   // Initialize all pins to NONE
   for (int i = 0; i < MAX_PINS; i++) {
     _buttonMap[i] = ButtonAction::NONE;
+    _lastDebounceTime[i] = 0;
+    _lastButtonState[i] = HIGH; // Pull-up means default state is HIGH
+    _buttonState[i] = HIGH;
   }
 }
 
@@ -25,6 +28,9 @@ void ControlPad::addButton(int pin, ButtonAction buttonAction) {
 
   _buttonMap[pin] = buttonAction;
   _activePins[_activePinCount++] = pin;
+  _lastDebounceTime[pin] = 0;
+  _lastButtonState[pin] = HIGH;
+  _buttonState[pin] = HIGH;
   pinMode(pin, INPUT_PULLUP); // Configure pin as input with pull-up resistor
 }
 
@@ -32,14 +38,29 @@ ButtonAction ControlPad::read() {
   int pressedCount = 0;
   ButtonAction pressedAction = ButtonAction::NONE;
 
+  unsigned long now = millis();
+
   for (int i = 0; i < _activePinCount; i++) {
     int pin = _activePins[i];
-    // If a button action is assigned to this pin
-    if (_buttonMap[pin] != ButtonAction::NONE) {
-      if (digitalRead(pin) == LOW) { // Button is pressed (LOW due to INPUT_PULLUP)
-        pressedCount++;
-        pressedAction = _buttonMap[pin];
+
+    int reading = digitalRead(pin);
+
+    if (reading != _lastButtonState[pin]) {
+      _lastDebounceTime[pin] = now;
+    }
+
+    if ((now - _lastDebounceTime[pin]) > DEBOUNCE_DELAY) {
+      if (reading != _buttonState[pin]) {
+        _buttonState[pin] = reading;
       }
+    }
+
+    _lastButtonState[pin] = reading;
+
+    // Use the debounced state
+    if (_buttonState[pin] == LOW) { // Button is pressed (LOW due to INPUT_PULLUP)
+      pressedCount++;
+      pressedAction = _buttonMap[pin];
     }
   }
 

--- a/src/farkle/lib/components/ControlPad/ControlPad.h
+++ b/src/farkle/lib/components/ControlPad/ControlPad.h
@@ -5,6 +5,7 @@
 #include "ButtonActions.h"
 
 #define MAX_PINS 17 // Max pin number + 1 to support up to pin 16
+#define DEBOUNCE_DELAY 50 // ms
 
 class ControlPad {
 public:
@@ -17,6 +18,11 @@ private:
   ButtonAction _lastAction;
   int _activePins[MAX_PINS];
   int _activePinCount;
+
+  // Debouncing state
+  unsigned long _lastDebounceTime[MAX_PINS];
+  int _lastButtonState[MAX_PINS];
+  int _buttonState[MAX_PINS];
 };
 
 #endif

--- a/src/farkle/test/test_component_control_pad/test_control_pad.cpp
+++ b/src/farkle/test/test_component_control_pad/test_control_pad.cpp
@@ -57,6 +57,8 @@ void test_read_valid_button(void) {
 
     // Simulate button press (LOW)
     setMockPinState(pin, LOW);
+    controlPad->read(); // Start debounce
+    advance_millis(DEBOUNCE_DELAY + 1);
 
     TEST_ASSERT_EQUAL(action, controlPad->read());
 }
@@ -88,9 +90,33 @@ void test_add_duplicate_pin_fails(void) {
 
     // Press the button
     setMockPinState(pin, LOW);
+    controlPad->read(); // Start debounce
+    advance_millis(DEBOUNCE_DELAY + 1);
 
     // Should still return BANK (first action)
     TEST_ASSERT_EQUAL(ButtonAction::BANK, controlPad->read());
+}
+
+void test_read_with_bouncing(void) {
+    int pin = 5;
+    ButtonAction action = ButtonAction::CLEAR;
+    controlPad->addButton(pin, action);
+
+    // 1. Initial press (LOW)
+    setMockPinState(pin, LOW);
+    controlPad->read(); // Trigger debounce timer
+    advance_millis(DEBOUNCE_DELAY + 1);
+    TEST_ASSERT_EQUAL(action, controlPad->read());
+
+    // 2. Bounce to HIGH (released) briefly
+    setMockPinState(pin, HIGH);
+    controlPad->read(); // Should still be debounced as LOW
+    TEST_ASSERT_EQUAL(ButtonAction::NONE, controlPad->read()); // NONE because pressedAction (action) == _lastAction (action)
+
+    // 3. Bounce back to LOW (pressed)
+    setMockPinState(pin, LOW);
+    // Should still return NONE because it never stabilized at HIGH
+    TEST_ASSERT_EQUAL(ButtonAction::NONE, controlPad->read());
 }
 
 int main(int argc, char **argv) {
@@ -101,5 +127,6 @@ int main(int argc, char **argv) {
     RUN_TEST(test_read_valid_button);
     RUN_TEST(test_add_none_action_fails);
     RUN_TEST(test_add_duplicate_pin_fails);
+    RUN_TEST(test_read_with_bouncing);
     return UNITY_END();
 }


### PR DESCRIPTION
This change implements software debouncing for the ControlPad component to resolve issues where buttons would occasionally register multiple times or flicker. Each pin now has its own debounce timer and state tracking. The DEBOUNCE_DELAY is set to 50ms, which is a standard value for human-operated buttons. Corresponding unit tests have been updated and a new bouncing test case was added to verify the fix.

Fixes #77

---
*PR created automatically by Jules for task [14456068342108760704](https://jules.google.com/task/14456068342108760704) started by @gwenrich136*