### PR TITLE
Improve TextDisplay Stability and Implement Missing Methods

### DIFF
--- a/src/farkle/lib/components/TextDisplay/TextDisplay.cpp
+++ b/src/farkle/lib/components/TextDisplay/TextDisplay.cpp
@@ -1,9 +1,20 @@
 #include "TextDisplay.h"
 #include <Wire.h> // Include Wire.h for I2C communication
 #include <Arduino.h>
+#include <string.h>
 
-TextDisplay::TextDisplay() : _display(U8G2_SH1106_128X64_NONAME_1_HW_I2C(U8G2_R0, U8X8_PIN_NONE)), _currentMode(DisplayMode::NONE)
-{}
+TextDisplay::TextDisplay() :
+    _display(U8G2_SH1106_128X64_NONAME_1_HW_I2C(U8G2_R0, U8X8_PIN_NONE)),
+    _currentMode(DisplayMode::NONE),
+    _lastActiveIndex(-1)
+{
+    _lastMessage[0] = '\0';
+    _lastTitle[0] = '\0';
+    _lastItem[0] = '\0';
+    _lastSubtitle[0] = '\0';
+    _lastLeftSubtitle[0] = '\0';
+    _lastRightSubtitle[0] = '\0';
+}
 
 void TextDisplay::begin() {
   Serial.println("    TEXT: Calling Wire.begin()...");
@@ -14,7 +25,11 @@ void TextDisplay::begin() {
   _display.setI2CAddress(0x3C * 2); // Explicitly set I2C address
   
   Serial.println("    TEXT: Calling U8g2.begin()...");
-  _display.begin();
+  if (_display.begin()) {
+      Serial.println("    TEXT: U8g2.begin() succeeded.");
+  } else {
+      Serial.println("    TEXT: U8g2.begin() FAILED!");
+  }
   
   // Configure deterministic font behavior
   _display.setFontPosTop();
@@ -23,17 +38,74 @@ void TextDisplay::begin() {
   Serial.println("    TEXT: Init complete.");
 }
 
+bool TextDisplay::shouldRedraw(DisplayMode mode, const char* s1, const char* s2, const char* s3, int index) {
+    bool redraw = false;
+    if (_currentMode != mode) redraw = true;
+
+    // Mapping of s1, s2, s3 depends on mode, but we can just check all provided ones
+    // and compare against their corresponding "last" fields based on the mode.
+    // To keep it simple, let's just map them consistently for each mode:
+    // MESSAGE: s1=message
+    // SELECTION: s1=title, s2=item
+    // TITLE: s1=title
+    // TITLE_SUBTITLE: s1=title, s2=subtitle
+    // TITLE_SUBTITLES: s1=title, s2=left, s3=right
+    // CHARACTER_INPUT: s1=name, index=activeIndex
+
+    if (mode == DisplayMode::MESSAGE) {
+        if (s1 && strcmp(_lastMessage, s1) != 0) redraw = true;
+    } else if (mode == DisplayMode::SELECTION) {
+        if (s1 && strcmp(_lastTitle, s1) != 0) redraw = true;
+        if (s2 && strcmp(_lastItem, s2) != 0) redraw = true;
+    } else if (mode == DisplayMode::TITLE) {
+        if (s1 && strcmp(_lastTitle, s1) != 0) redraw = true;
+    } else if (mode == DisplayMode::TITLE_SUBTITLE) {
+        if (s1 && strcmp(_lastTitle, s1) != 0) redraw = true;
+        if (s2 && strcmp(_lastSubtitle, s2) != 0) redraw = true;
+    } else if (mode == DisplayMode::TITLE_SUBTITLES) {
+        if (s1 && strcmp(_lastTitle, s1) != 0) redraw = true;
+        if (s2 && strcmp(_lastLeftSubtitle, s2) != 0) redraw = true;
+        if (s3 && strcmp(_lastRightSubtitle, s3) != 0) redraw = true;
+    } else if (mode == DisplayMode::CHARACTER_INPUT) {
+        if (s1 && strcmp(_lastMessage, s1) != 0) redraw = true;
+        if (index != _lastActiveIndex) redraw = true;
+    }
+
+    if (redraw) {
+        Serial.print("    TEXT: Redraw triggered for mode ");
+        Serial.println((int)mode);
+        _currentMode = mode;
+        if (mode == DisplayMode::MESSAGE || mode == DisplayMode::CHARACTER_INPUT) {
+            if (s1) { strncpy(_lastMessage, s1, TEXT_DISPLAY_BUFFER_SIZE - 1); _lastMessage[TEXT_DISPLAY_BUFFER_SIZE - 1] = '\0'; }
+        }
+        if (mode == DisplayMode::SELECTION || mode == DisplayMode::TITLE || mode == DisplayMode::TITLE_SUBTITLE || mode == DisplayMode::TITLE_SUBTITLES) {
+            if (s1) { strncpy(_lastTitle, s1, TEXT_DISPLAY_BUFFER_SIZE - 1); _lastTitle[TEXT_DISPLAY_BUFFER_SIZE - 1] = '\0'; }
+        }
+        if (mode == DisplayMode::SELECTION) {
+            if (s2) { strncpy(_lastItem, s2, TEXT_DISPLAY_BUFFER_SIZE - 1); _lastItem[TEXT_DISPLAY_BUFFER_SIZE - 1] = '\0'; }
+        }
+        if (mode == DisplayMode::TITLE_SUBTITLE) {
+            if (s2) { strncpy(_lastSubtitle, s2, TEXT_DISPLAY_BUFFER_SIZE - 1); _lastSubtitle[TEXT_DISPLAY_BUFFER_SIZE - 1] = '\0'; }
+        }
+        if (mode == DisplayMode::TITLE_SUBTITLES) {
+            if (s2) { strncpy(_lastLeftSubtitle, s2, TEXT_DISPLAY_BUFFER_SIZE - 1); _lastLeftSubtitle[TEXT_DISPLAY_BUFFER_SIZE - 1] = '\0'; }
+            if (s3) { strncpy(_lastRightSubtitle, s3, TEXT_DISPLAY_BUFFER_SIZE - 1); _lastRightSubtitle[TEXT_DISPLAY_BUFFER_SIZE - 1] = '\0'; }
+        }
+        _lastActiveIndex = index;
+    }
+    return redraw;
+}
+
 void TextDisplay::print(const char* message)
 {
-  if (_currentMode == DisplayMode::MESSAGE && _lastMessage == message) {
-    return; // Optimization: Don't redraw if text hasn't changed
+  if (!shouldRedraw(DisplayMode::MESSAGE, message)) {
+    return;
   }
-  _currentMode = DisplayMode::MESSAGE;
-  _lastMessage = message;
 
   _display.setFont(TEXT_DISPLAY_MAIN_FONT);
   int message_width = _display.getStrWidth(message);
   int x = (_display.getDisplayWidth() - message_width) / 2;
+  if (x < 0) x = 0;
   int y = (_display.getDisplayHeight() - TEXT_DISPLAY_MAIN_HEIGHT) / 2;
   
   _display.firstPage();
@@ -44,51 +116,152 @@ void TextDisplay::print(const char* message)
 
 void TextDisplay::printSelectionScreen(const char* selectionTitle, const char* selectionItem)
 {
-    if (_currentMode == DisplayMode::SELECTION && _lastTitle == selectionTitle && _lastItem == selectionItem) {
+    if (!shouldRedraw(DisplayMode::SELECTION, selectionTitle, selectionItem)) {
         return;
     }
-    _currentMode = DisplayMode::SELECTION;
-    _lastTitle = selectionTitle;
-    _lastItem = selectionItem;
 
-    // 1. Pre-calculate horizontal alignment
     _display.setFont(TEXT_DISPLAY_TITLE_FONT);
     int titleWidth = _display.getStrWidth(selectionTitle);
     int titleX = (_display.getDisplayWidth() - titleWidth) / 2;
+    if (titleX < 0) titleX = 0;
 
     _display.setFont(TEXT_DISPLAY_MAIN_FONT);
     int itemWidth = _display.getStrWidth(selectionItem);
     int itemX = (_display.getDisplayWidth() - itemWidth) / 2;
+    if (itemX < 0) itemX = 0;
     int centerX = _display.getDisplayWidth() / 2;
 
-    // 2. Pre-calculate vertical positioning (Deterministic)
-    int titleY = 2; // Fixed top margin (with setFontPosTop)
-    int itemY = 38; // Pushed down to create more space from title
+    int titleY = 2;
+    int itemY = 38;
 
-    // 3. Pre-calculate arrow geometry
-    int arrowWidth = TEXT_DISPLAY_ARROW_WIDTH;
     int arrowHeight = TEXT_DISPLAY_ARROW_HEIGHT;
     int arrowSpacing = TEXT_DISPLAY_ARROW_SPACING;
-    
-    // Up arrow is above the item text
     int upArrowCenterY = itemY - arrowSpacing - arrowHeight/2;
-    // Down arrow is below the item text
     int downArrowCenterY = itemY + TEXT_DISPLAY_MAIN_HEIGHT + arrowSpacing + arrowHeight/2;
 
     _display.firstPage();
     do {
-        // Draw Title
         _display.setFont(TEXT_DISPLAY_TITLE_FONT);
         _display.drawStr(titleX, titleY, selectionTitle);
-
-        // Draw Item
         _display.setFont(TEXT_DISPLAY_MAIN_FONT);
         _display.drawStr(itemX, itemY, selectionItem);
-
-        // Draw Arrows
         drawArrow(centerX, upArrowCenterY, true);
         drawArrow(centerX, downArrowCenterY, false);
+    } while (_display.nextPage());
+}
 
+void TextDisplay::displayTitle(const char* title) {
+    if (!shouldRedraw(DisplayMode::TITLE, title)) return;
+
+    _display.setFont(TEXT_DISPLAY_LARGE_FONT);
+    int w = _display.getStrWidth(title);
+    int x = (_display.getDisplayWidth() - w) / 2;
+    if (x < 0) x = 0;
+    int y = (_display.getDisplayHeight() - TEXT_DISPLAY_LARGE_HEIGHT) / 2;
+
+    _display.firstPage();
+    do {
+        _display.drawStr(x, y, title);
+    } while (_display.nextPage());
+}
+
+void TextDisplay::displayTitleWithSubtitle(const char* title, const char* subtitle) {
+    if (!shouldRedraw(DisplayMode::TITLE_SUBTITLE, title, subtitle)) return;
+
+    _display.setFont(TEXT_DISPLAY_LARGE_FONT);
+    int tw = _display.getStrWidth(title);
+    int tx = (_display.getDisplayWidth() - tw) / 2;
+    if (tx < 0) tx = 0;
+
+    _display.setFont(TEXT_DISPLAY_TITLE_FONT);
+    int sw = _display.getStrWidth(subtitle);
+    int sx = (_display.getDisplayWidth() - sw) / 2;
+    if (sx < 0) sx = 0;
+
+    int ty = 10;
+    int sy = 45;
+
+    _display.firstPage();
+    do {
+        _display.setFont(TEXT_DISPLAY_LARGE_FONT);
+        _display.drawStr(tx, ty, title);
+        _display.setFont(TEXT_DISPLAY_TITLE_FONT);
+        _display.drawStr(sx, sy, subtitle);
+    } while (_display.nextPage());
+}
+
+void TextDisplay::displayTitleWithSubtitles(const char* title, const char* leftSubtitle, const char* rightSubtitle) {
+    if (!shouldRedraw(DisplayMode::TITLE_SUBTITLES, title, leftSubtitle, rightSubtitle)) return;
+
+    _display.setFont(TEXT_DISPLAY_LARGE_FONT);
+    int tw = _display.getStrWidth(title);
+    int tx = (_display.getDisplayWidth() - tw) / 2;
+    if (tx < 0) tx = 0;
+
+    _display.setFont(TEXT_DISPLAY_TITLE_FONT);
+    // leftSubtitle at x=2, rightSubtitle at x = width - sw - 2
+    int swRight = _display.getStrWidth(rightSubtitle);
+    int sxLeft = 2;
+    int sxRight = _display.getDisplayWidth() - swRight - 2;
+
+    int ty = 10;
+    int sy = 45;
+
+    _display.firstPage();
+    do {
+        _display.setFont(TEXT_DISPLAY_LARGE_FONT);
+        _display.drawStr(tx, ty, title);
+        _display.setFont(TEXT_DISPLAY_TITLE_FONT);
+        _display.drawStr(sxLeft, sy, leftSubtitle);
+        _display.drawStr(sxRight, sy, rightSubtitle);
+    } while (_display.nextPage());
+}
+
+void TextDisplay::displayCharacterInput(const char* currentName, int activeIndex) {
+    if (!shouldRedraw(DisplayMode::CHARACTER_INPUT, currentName, nullptr, nullptr, activeIndex)) return;
+
+    int len = strlen(currentName);
+    if (activeIndex < 0 || activeIndex >= len) return;
+
+    char activeChar[2] = { currentName[activeIndex], '\0' };
+
+    _display.setFont(TEXT_DISPLAY_LARGE_FONT);
+    int aw = _display.getStrWidth(activeChar);
+    int ax = (_display.getDisplayWidth() - aw) / 2;
+    int ay = (_display.getDisplayHeight() - TEXT_DISPLAY_LARGE_HEIGHT) / 2;
+
+    // Arrows for active char
+    int arrowHeight = TEXT_DISPLAY_ARROW_HEIGHT;
+    int arrowSpacing = TEXT_DISPLAY_ARROW_SPACING;
+    int centerX = _display.getDisplayWidth() / 2;
+    int upArrowY = ay - arrowSpacing - arrowHeight/2;
+    int downArrowY = ay + TEXT_DISPLAY_LARGE_HEIGHT + arrowSpacing + arrowHeight/2;
+
+    _display.firstPage();
+    do {
+        // Draw active character
+        _display.setFont(TEXT_DISPLAY_LARGE_FONT);
+        _display.drawStr(ax, ay, activeChar);
+
+        // Draw Arrows
+        drawArrow(centerX, upArrowY, true);
+        drawArrow(centerX, downArrowY, false);
+
+        // Draw left part of the name
+        _display.setFont(TEXT_DISPLAY_TITLE_FONT);
+        if (activeIndex > 0) {
+            char leftPart[64];
+            strncpy(leftPart, currentName, activeIndex);
+            leftPart[activeIndex] = '\0';
+            int lw = _display.getStrWidth(leftPart);
+            _display.drawStr(ax - lw - 4, ay + (TEXT_DISPLAY_LARGE_HEIGHT - TEXT_DISPLAY_TITLE_HEIGHT)/2, leftPart);
+        }
+
+        // Draw right part of the name
+        if (activeIndex < len - 1) {
+            const char* rightPart = &currentName[activeIndex + 1];
+            _display.drawStr(ax + aw + 4, ay + (TEXT_DISPLAY_LARGE_HEIGHT - TEXT_DISPLAY_TITLE_HEIGHT)/2, rightPart);
+        }
     } while (_display.nextPage());
 }
 
@@ -97,11 +270,9 @@ void TextDisplay::drawArrow(int x, int y, bool up) {
     int halfH = TEXT_DISPLAY_ARROW_HEIGHT / 2;
     
     if (up) {
-        // Tip (x, y-halfH), Left (x-halfW, y+halfH), Right (x+halfW, y+halfH)
         _display.drawLine(x - halfW, y + halfH, x, y - halfH);
         _display.drawLine(x + halfW, y + halfH, x, y - halfH);
     } else {
-        // Tip (x, y+halfH), Left (x-halfW, y-halfH), Right (x+halfW, y-halfH)
         _display.drawLine(x - halfW, y - halfH, x, y + halfH);
         _display.drawLine(x + halfW, y - halfH, x, y + halfH);
     }

--- a/src/farkle/lib/components/TextDisplay/TextDisplay.h
+++ b/src/farkle/lib/components/TextDisplay/TextDisplay.h
@@ -3,43 +3,65 @@
 
 #include <Arduino.h>
 #include <U8g2lib.h> // Include U8g2 library
-#include <string>
 
 // Define fonts as macros for easy configuration
 #define TEXT_DISPLAY_MAIN_FONT u8g2_font_ncenB10_tr
 #define TEXT_DISPLAY_TITLE_FONT u8g2_font_ncenB08_tr
+#define TEXT_DISPLAY_LARGE_FONT u8g2_font_ncenB18_tr
 #define TEXT_DISPLAY_MAIN_HEIGHT 15
 #define TEXT_DISPLAY_TITLE_HEIGHT 12
+#define TEXT_DISPLAY_LARGE_HEIGHT 24
 
 // Define arrow geometry
 #define TEXT_DISPLAY_ARROW_WIDTH 10
 #define TEXT_DISPLAY_ARROW_HEIGHT 4
 #define TEXT_DISPLAY_ARROW_SPACING 2 // Vertical spacing from text
 
+// Buffer size for text caching
+#define TEXT_DISPLAY_BUFFER_SIZE 64
+
 enum class DisplayMode {
     NONE,
     MESSAGE,
-    SELECTION
+    SELECTION,
+    TITLE,
+    TITLE_SUBTITLE,
+    TITLE_SUBTITLES,
+    CHARACTER_INPUT
 };
 
 class TextDisplay
 {
   public:
     TextDisplay();
+    void begin();
+
+    // API from COMPONENT_LIBRARIES.md
     void print(const char* message);
     void printSelectionScreen(const char* selectionTitle, const char* selectionItem);
-    void begin();
+    void displayTitle(const char* title);
+    void displayTitleWithSubtitle(const char* title, const char* subtitle);
+    void displayTitleWithSubtitles(const char* title, const char* leftSubtitle, const char* rightSubtitle);
+    void displayCharacterInput(const char* currentName, int activeIndex);
+
   private:
     U8G2_SH1106_128X64_NONAME_1_HW_I2C _display;
 
     // State tracking
     DisplayMode _currentMode;
-    std::string _lastMessage;
-    std::string _lastTitle;
-    std::string _lastItem;
+    char _lastMessage[TEXT_DISPLAY_BUFFER_SIZE];
+    char _lastTitle[TEXT_DISPLAY_BUFFER_SIZE];
+    char _lastItem[TEXT_DISPLAY_BUFFER_SIZE];
+    char _lastSubtitle[TEXT_DISPLAY_BUFFER_SIZE];
+    char _lastLeftSubtitle[TEXT_DISPLAY_BUFFER_SIZE];
+    char _lastRightSubtitle[TEXT_DISPLAY_BUFFER_SIZE];
+    int _lastActiveIndex;
 
     // Helper to draw arrow
     void drawArrow(int x, int y, bool up);
+
+    // Internal helper to update state and check if redraw is needed
+    bool shouldRedraw(DisplayMode mode, const char* s1 = nullptr, const char* s2 = nullptr, const char* s3 = nullptr, int index = -1);
 };
 
 #endif

--- a/src/farkle/test/mocks/include/Serial.h
+++ b/src/farkle/test/mocks/include/Serial.h
@@ -2,11 +2,15 @@
 #define MOCK_SERIAL_H
 
 #include <iostream>
+#include <string>
 
 class MockSerial {
 public:
     void begin(int baud) {}
     void println(const char* msg) {}
+    void println(int val) {}
+    void print(const char* msg) {}
+    void print(int val) {}
 };
 
 extern MockSerial Serial;

--- a/src/farkle/test/mocks/libs/U8g2lib.h
+++ b/src/farkle/test/mocks/libs/U8g2lib.h
@@ -13,6 +13,7 @@ typedef int u8g2_uint_t;
 #define U8X8_PIN_NONE 255
 extern const uint8_t u8g2_font_ncenB10_tr[];
 extern const uint8_t u8g2_font_ncenB08_tr[]; // For smaller font if needed
+extern const uint8_t u8g2_font_ncenB18_tr[]; // For large font
 
 // Rotation callback mock
 extern void u8g2_cb_r0(void);
@@ -45,14 +46,16 @@ public:
 
     void setI2CAddress(uint8_t adr) {}
 
-    void begin() {
+    uint8_t begin() {
         mockU8g2BeginCount++;
+        return 1;
     }
 
     void setFont(const uint8_t *font) {
         mockU8g2SetFontCount++;
         if (font == u8g2_font_ncenB10_tr) mockU8g2LastFont = "ncenB10";
         else if (font == u8g2_font_ncenB08_tr) mockU8g2LastFont = "ncenB08";
+        else if (font == u8g2_font_ncenB18_tr) mockU8g2LastFont = "ncenB18";
         else mockU8g2LastFont = "unknown";
     }
 

--- a/src/farkle/test/mocks/src/U8g2lib.cpp
+++ b/src/farkle/test/mocks/src/U8g2lib.cpp
@@ -3,6 +3,7 @@
 // Define constants
 const uint8_t u8g2_font_ncenB10_tr[1] = {0};
 const uint8_t u8g2_font_ncenB08_tr[1] = {0};
+const uint8_t u8g2_font_ncenB18_tr[1] = {0};
 
 void u8g2_cb_r0(void) {}
 

--- a/src/farkle/test/test_component_text_display/test_TextDisplay.cpp
+++ b/src/farkle/test/test_component_text_display/test_TextDisplay.cpp
@@ -113,6 +113,65 @@ void test_selection_screen_caching(void) {
     TEST_ASSERT_TRUE(mockU8g2DrawStrCalls.size() > initialCalls);
 }
 
+void test_displayTitle(void) {
+    textDisplay->displayTitle("Victory!");
+    TEST_ASSERT_EQUAL(2, mockU8g2DrawStrCalls.size());
+    TEST_ASSERT_EQUAL_STRING("Victory!", mockU8g2DrawStrCalls[0].str.c_str());
+    TEST_ASSERT_EQUAL_STRING("ncenB18", mockU8g2LastFont.c_str());
+}
+
+void test_displayTitleWithSubtitle(void) {
+    textDisplay->displayTitleWithSubtitle("Level 1", "Starting...");
+    // 2 pages * 2 strings = 4 calls
+    TEST_ASSERT_EQUAL(4, mockU8g2DrawStrCalls.size());
+    TEST_ASSERT_EQUAL_STRING("Level 1", mockU8g2DrawStrCalls[0].str.c_str());
+    TEST_ASSERT_EQUAL_STRING("Starting...", mockU8g2DrawStrCalls[1].str.c_str());
+}
+
+void test_displayTitleWithSubtitles(void) {
+    textDisplay->displayTitleWithSubtitles("Game Over", "Score: 100", "Time: 5:00");
+    // 2 pages * 3 strings = 6 calls
+    TEST_ASSERT_EQUAL(6, mockU8g2DrawStrCalls.size());
+    TEST_ASSERT_EQUAL_STRING("Game Over", mockU8g2DrawStrCalls[0].str.c_str());
+    TEST_ASSERT_EQUAL_STRING("Score: 100", mockU8g2DrawStrCalls[1].str.c_str());
+    TEST_ASSERT_EQUAL_STRING("Time: 5:00", mockU8g2DrawStrCalls[2].str.c_str());
+}
+
+void test_displayCharacterInput(void) {
+    textDisplay->displayCharacterInput("ABC", 1); // Editing 'B'
+    // Draw active char ('B'), left part ('A'), right part ('C') per page.
+    // 2 pages * 3 strings = 6 calls.
+    TEST_ASSERT_EQUAL(6, mockU8g2DrawStrCalls.size());
+
+    // Check order (Active, Left, Right as per implementation)
+    TEST_ASSERT_EQUAL_STRING("B", mockU8g2DrawStrCalls[0].str.c_str());
+    TEST_ASSERT_EQUAL_STRING("A", mockU8g2DrawStrCalls[1].str.c_str());
+    TEST_ASSERT_EQUAL_STRING("C", mockU8g2DrawStrCalls[2].str.c_str());
+
+    // Verify arrows (2 arrows * 2 lines * 2 pages = 8 lines)
+    TEST_ASSERT_EQUAL(8, mockU8g2DrawLineCalls.size());
+}
+
+void test_clamping(void) {
+    // Very long string. Mock getStrWidth returns length * 10.
+    // "This is a very long string that should definitely exceed 128 pixels" is > 13 chars.
+    textDisplay->print("This is a very long string that will be clamped");
+    // Initial x calculation: (128 - (46*10))/2 = (128 - 460)/2 = -166.
+    // Clamping should set it to 0.
+    TEST_ASSERT_EQUAL(0, mockU8g2DrawStrCalls[0].x);
+}
+
+void test_buffer_caching_full(void) {
+    textDisplay->displayTitle("A");
+    int calls = mockU8g2DrawStrCalls.size();
+
+    textDisplay->displayTitle("A"); // Cached
+    TEST_ASSERT_EQUAL(calls, mockU8g2DrawStrCalls.size());
+
+    textDisplay->displayTitle("B"); // Redraw
+    TEST_ASSERT_TRUE(mockU8g2DrawStrCalls.size() > calls);
+}
+
 int main(int argc, char **argv) {
     UNITY_BEGIN();
     RUN_TEST(test_begin);
@@ -121,6 +180,12 @@ int main(int argc, char **argv) {
     RUN_TEST(test_printSelectionScreen);
     RUN_TEST(test_mode_switching);
     RUN_TEST(test_selection_screen_caching);
+    RUN_TEST(test_displayTitle);
+    RUN_TEST(test_displayTitleWithSubtitle);
+    RUN_TEST(test_displayTitleWithSubtitles);
+    RUN_TEST(test_displayCharacterInput);
+    RUN_TEST(test_clamping);
+    RUN_TEST(test_buffer_caching_full);
     UNITY_END();
     return 0;
 }


### PR DESCRIPTION
This submission fixes the stability issues reported for the TextDisplay component (OLED). The primary cause of the 'off the rails' behavior was likely heap fragmentation from std::string usage in the embedded environment. I've refactored the caching logic to use fixed-size buffers and implemented the missing methods defined in the design documentation. Robustness has been improved with coordinate clamping and better logging. All tests pass.

Fixes #80

---
*PR created automatically by Jules for task [5159815645827725703](https://jules.google.com/task/5159815645827725703) started by @gwenrich136*