### PR TITLE
Remove score history from GameState and design docs

### DIFF
--- a/design/GENERAL_GAME_PLAY.md
+++ b/design/GENERAL_GAME_PLAY.md
@@ -1,4 +1,4 @@
-> **Scope:** Defines the complete user experience and gameplay flow, from pre-game setup to post-game results, from a player's perspective.
+> **Scope:** Defines the complete user experience and gameplay flow, from pre-game setup to post-game replays, from a player's perspective.
 > **Status:** **LIVE DOCUMENT** - This file represents the current source of truth. If code changes, this document MUST be updated.
 
 # General Gameplay and User Experience Design for Farkle Scoreboard
@@ -115,8 +115,9 @@ The game begins by guiding players through setup and configuration.
 
 After the winner celebration, the device enters a continuous post-game loop.
 
-### 4.1 Game Data Upload
--   **Data Upload (Background/Interactive):** The scoreboard attempts to connect via Bluetooth or WiFi to a paired phone.
+### 4.1 Game Replay & Upload (Parallel)
+-   **Visual Replay:** The `LedProgressGrid` continuously replays the game's progress, showing how each player's score advanced throughout the session.
+-   **Data Upload (Background/Interactive):** Simultaneously, the scoreboard attempts to connect via Bluetooth or WiFi to a paired phone.
     -   The `TextDisplay` provides status updates (e.g., "CONNECTING...", "UPLOADING...").
     -   If the upload is successful, the `TextDisplay` indicates this.
     -   If the connection or upload fails, the `TextDisplay` presents a menu of options.
@@ -127,6 +128,7 @@ After the winner celebration, the device enters a continuous post-game loop.
     1.  "Retry Upload": Re-attempts the data upload.
     2.  "Play Again": Leads to a "Reset Game?" confirmation.
 -   **Navigation:** Users navigate this menu using `Up/Down` and select options with `BANK`.
+-   **`LedProgressGrid` Behavior:** The `LedProgressGrid` continues its game replay animation independently while the user interacts with the `TextDisplay` menu.
 
 ### 4.3 Reset Game
 -   **Confirmation:** Selecting "Play Again" or triggering a reset (e.g., via `CLEAR` from a specific context) leads to a "Reset Game?" confirmation screen.

--- a/design/GENERAL_GAME_PLAY.md
+++ b/design/GENERAL_GAME_PLAY.md
@@ -1,4 +1,4 @@
-> **Scope:** Defines the complete user experience and gameplay flow, from pre-game setup to post-game replays, from a player's perspective.
+> **Scope:** Defines the complete user experience and gameplay flow, from pre-game setup to post-game results, from a player's perspective.
 > **Status:** **LIVE DOCUMENT** - This file represents the current source of truth. If code changes, this document MUST be updated.
 
 # General Gameplay and User Experience Design for Farkle Scoreboard
@@ -115,9 +115,8 @@ The game begins by guiding players through setup and configuration.
 
 After the winner celebration, the device enters a continuous post-game loop.
 
-### 4.1 Game Replay & Upload (Parallel)
--   **Visual Replay:** The `LedProgressGrid` continuously replays the entire game's score history, showing how each player's score progressed throughout the game.
--   **Data Upload (Background/Interactive):** Simultaneously, the scoreboard attempts to connect via Bluetooth or WiFi to a paired phone.
+### 4.1 Game Data Upload
+-   **Data Upload (Background/Interactive):** The scoreboard attempts to connect via Bluetooth or WiFi to a paired phone.
     -   The `TextDisplay` provides status updates (e.g., "CONNECTING...", "UPLOADING...").
     -   If the upload is successful, the `TextDisplay` indicates this.
     -   If the connection or upload fails, the `TextDisplay` presents a menu of options.
@@ -128,8 +127,7 @@ After the winner celebration, the device enters a continuous post-game loop.
     1.  "Retry Upload": Re-attempts the data upload.
     2.  "Play Again": Leads to a "Reset Game?" confirmation.
 -   **Navigation:** Users navigate this menu using `Up/Down` and select options with `BANK`.
--   **`LedProgressGrid` Behavior:** The `LedProgressGrid` continues its game replay animation independently while the user interacts with the `TextDisplay` menu.
 
 ### 4.3 Reset Game
 -   **Confirmation:** Selecting "Play Again" or triggering a reset (e.g., via `CLEAR` from a specific context) leads to a "Reset Game?" confirmation screen.
--   **Action:** Confirming the reset wipes all game history and returns the device to the initial "Target Score Selection" state.
+-   **Action:** Confirming the reset returns the device to the initial "Target Score Selection" state.

--- a/design/TECHNICAL_DESIGN_GAME_STATE_MACHINE.md
+++ b/design/TECHNICAL_DESIGN_GAME_STATE_MACHINE.md
@@ -5,7 +5,7 @@
 
 ## 1. Problem Statement
 
-The Farkle Scoreboard requires a formal system to manage the flow of the game. As the game's complexity grows with different user interactions (pre-game setup, in-game scoring, animations, and post-game results), an ad-hoc approach using simple `if/else` blocks or flags in the main loop will become unmanageable, bug-prone, and difficult to extend.
+The Farkle Scoreboard requires a formal system to manage the flow of the game. As the game's complexity grows with different user interactions (pre-game setup, in-game scoring, animations, post-game replays), an ad-hoc approach using simple `if/else` blocks or flags in the main loop will become unmanageable, bug-prone, and difficult to extend.
 
 This document specifies a robust and scalable state machine architecture that provides a clear structure for game logic, ensures state transitions are handled safely, and allows for new features and game phases to be added in a clean, modular way.
 

--- a/design/TECHNICAL_DESIGN_GAME_STATE_MACHINE.md
+++ b/design/TECHNICAL_DESIGN_GAME_STATE_MACHINE.md
@@ -5,7 +5,7 @@
 
 ## 1. Problem Statement
 
-The Farkle Scoreboard requires a formal system to manage the flow of the game. As the game's complexity grows with different user interactions (pre-game setup, in-game scoring, animations, post-game replays), an ad-hoc approach using simple `if/else` blocks or flags in the main loop will become unmanageable, bug-prone, and difficult to extend.
+The Farkle Scoreboard requires a formal system to manage the flow of the game. As the game's complexity grows with different user interactions (pre-game setup, in-game scoring, animations, and post-game results), an ad-hoc approach using simple `if/else` blocks or flags in the main loop will become unmanageable, bug-prone, and difficult to extend.
 
 This document specifies a robust and scalable state machine architecture that provides a clear structure for game logic, ensures state transitions are handled safely, and allows for new features and game phases to be added in a clean, modular way.
 
@@ -88,7 +88,7 @@ The following files will be created or modified to implement the Game State Mach
 *   **`src/farkle/include/GameState.h`**
     *   **Why:** Defines the core data structures, keeping data separate from logic.
     *   **Implementation Details:**
-        *   `struct Player`: Will contain `std::string name;`, `int score;`, `int farkle_count;`, and `std::vector<int> score_history;`.
+        *   `struct Player`: Will contain `std::string name;`, `int score;`, and `int farkle_count;`.
         *   `struct GameState`: Will contain `std::vector<Player> players;`, `int atRiskScore;`, `int currentPlayerIndex;`, `bool finalRoundTriggered = false;`, `int targetScore = 10000;`, `uint32_t scoresVersion`.
         *   `void reset()`: Resets all flags, clears the player list, and increments `scoresVersion`.
         *   `void updatePlayerScore(int playerIndex, int newScore)`: Helper to update score and increment `scoresVersion`.

--- a/src/farkle/include/GameState.h
+++ b/src/farkle/include/GameState.h
@@ -9,7 +9,6 @@ struct Player {
     std::string name;
     int score;
     int farkle_count;
-    std::vector<int> score_history;
 
     Player(const std::string& n) : name(n), score(0), farkle_count(0) {}
 };


### PR DESCRIPTION
This change removes the `score_history` variable from the `Player` struct in the Arduino memory (`GameState.h`) to save RAM. It also updates the design documents to remove all references to game history and post-game visual replays, as these features will be handled differently (e.g., via SD card) in the future. All existing tests pass, confirming that no current logic relied on the `score_history` variable.

Fixes #101

---
*PR created automatically by Jules for task [7932320254900351052](https://jules.google.com/task/7932320254900351052) started by @gwenrich136*