### PR TITLE
Unify MAX_PLAYERS constant into GameConstants.h

### DIFF
--- a/design/TECHNICAL_DESIGN_GAME_STATE_MACHINE.md
+++ b/design/TECHNICAL_DESIGN_GAME_STATE_MACHINE.md
@@ -74,6 +74,11 @@ After considering multiple alternatives, we have chosen to implement the **State
 The following files will be created or modified to implement the Game State Machine, following a "Pure State" architectural pattern where the `Game` class acts as a generic engine and all game logic is encapsulated within the `GamePhase` classes.
 
 #### New Files - Common Definitions
+*   **`src/farkle/include/GameConstants.h`**
+    *   **Why:** Defines global constants used across the game logic and hardware components, ensuring a single source of truth.
+    *   **Implementation Details:**
+        *   `#define MAX_PLAYERS 8`
+
 *   **`src/farkle/include/Input.h`**
     *   **Why:** Defines the input structures used by the `Game` engine and its phases.
     *   **Implementation Details:**

--- a/src/farkle/include/GameConstants.h
+++ b/src/farkle/include/GameConstants.h
@@ -1,0 +1,6 @@
+#ifndef GameConstants_h
+#define GameConstants_h
+
+#define MAX_PLAYERS 8
+
+#endif

--- a/src/farkle/lib/components/FarkleWarningLights/FarkleWarningLights.h
+++ b/src/farkle/lib/components/FarkleWarningLights/FarkleWarningLights.h
@@ -4,8 +4,7 @@
 #include "Arduino.h"
 #include <Adafruit_NeoPixel.h>
 #include "PlayerLayout.h"
-
-#define MAX_PLAYERS 8
+#include "GameConstants.h"
 
 class FarkleWarningLights
 {

--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.h
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.h
@@ -4,8 +4,7 @@
 #include <Arduino.h>
 #include <Adafruit_NeoPixel.h>
 #include "PlayerLayout.h"
-
-#define MAX_PLAYERS 8
+#include "GameConstants.h"
 
 class LedProgressGrid {
 public:

--- a/src/farkle/src/phases/InGamePhase.cpp
+++ b/src/farkle/src/phases/InGamePhase.cpp
@@ -1,5 +1,6 @@
 #include "GamePhase.h"
 #include "GameState.h"
+#include "GameConstants.h"
 #include <vector>
 #include <Arduino.h>
 

--- a/src/farkle/src/phases/PlayerSelectionPhase.cpp
+++ b/src/farkle/src/phases/PlayerSelectionPhase.cpp
@@ -1,6 +1,7 @@
 #include "phases/PlayerSelectionPhase.h"
 #include "Game.h"
 #include <algorithm>
+#include "GameConstants.h"
 
 const std::vector<std::string> PlayerSelectionPhase::s_namePool = {
     "Geewee", "Sammy", "Coach", "Sheshe", "Alex", "Tigre", "Pepa", "Fred", "Andrea"
@@ -53,13 +54,15 @@ GamePhase* PlayerSelectionPhase::update(Game& game, GameState& state, GameInput 
 }
 
 void PlayerSelectionPhase::updateProgressGrid(const GameState& state, const Displays& displays) {
-    displays.grid.displayPlayersPregame(!displays.grid.isMaxPlayersReached());
+    bool isRosterFull = state.players.size() >= MAX_PLAYERS;
+    displays.grid.displayPlayersPregame(!isRosterFull);
 }
 
 void PlayerSelectionPhase::updateTextDisplay(const GameState& state, const Displays& displays) {
     // In the current configuration (pool=9, max=8), the list will never be empty before the roster is full.
     // However, we merge the conditions here as requested to simplify the logic.
-    if (displays.grid.isMaxPlayersReached() || m_availableNames.empty()) {
+    bool isRosterFull = state.players.size() >= MAX_PLAYERS;
+    if (isRosterFull || m_availableNames.empty()) {
         displays.oled.print("ROSTER FULL");
     } else {
         displays.oled.printSelectionScreen("Add Player", m_availableNames[m_selectionIndex].c_str());

--- a/src/farkle/src/phases/WaitingPhase.cpp
+++ b/src/farkle/src/phases/WaitingPhase.cpp
@@ -1,11 +1,7 @@
 #include "phases/WaitingPhase.h"
 #include "Game.h"
 #include <Arduino.h>
-
-// Ensure MAX_PLAYERS is available if not already defined (it is in FarkleWarningLights.h)
-#ifndef MAX_PLAYERS
-#define MAX_PLAYERS 8
-#endif
+#include "GameConstants.h"
 
 void WaitingPhase::onEnter(GameState& state) {
     // No specific local state to reset for WaitingPhase

--- a/src/farkle/test/mocks/include/LedProgressGrid.h
+++ b/src/farkle/test/mocks/include/LedProgressGrid.h
@@ -3,8 +3,7 @@
 
 #include <vector>
 #include <cstdint>
-
-#define MAX_PLAYERS 8
+#include "GameConstants.h"
 
 class LedProgressGrid {
 public:


### PR DESCRIPTION
This PR addresses issue #112 by unifying the `MAX_PLAYERS` constant into a single file `src/farkle/include/GameConstants.h`. This eliminates duplicate definitions across components (`FarkleWarningLights`, `LedProgressGrid`) and game logic (`WaitingPhase`). Additionally, `PlayerSelectionPhase` logic was refactored to use this constant directly instead of querying the `LedProgressGrid` component, decoupling the logic. All relevant tests passed.

---
*PR created automatically by Jules for task [17326375833152394804](https://jules.google.com/task/17326375833152394804) started by @gwenrich136*