### PR TITLE
Support multiple button presses in test_utils

### DIFF
--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -125,6 +125,9 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_PlayerSelection_TransitionValidation`**: Verifies that pressing **FARKLE** (Red) is ignored if the player list is empty, but successfully transitions to `WaitingPhase` if at least one player exists.
     *   **`test_PlayerSelection_AddLastPlayerWraps`**: Verifies that adding the last name in the filtered pool correctly wraps the selection index back to the first available name (index 0).
 
+*   **`test_multi_press.cpp`** (Test Utilities Verification)
+    *   **`test_simulate_button_press_count`**: Verifies that `simulateButtonPress` correctly interprets the optional `count` parameter to trigger multiple button presses in sequence, ensuring the test utility functions as intended.
+
 ### 4.2 MEDIUM Tests (Integration Tests)
 **Focus:** Handoffs. Verification of state persistence across phase transitions.
 **Location:** `test/test_game_logic/medium_tests/`

--- a/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
+++ b/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
@@ -15,9 +15,7 @@ void test_FullGame_StandardGame() {
 
     int turn = 0;
     while (game.currentPhase != game.getPhase<PostGamePhase_V1>() && turn < 100) {
-        simulateButtonPress(game, ButtonAction::PLUS_500);
-        simulateButtonPress(game, ButtonAction::PLUS_500);
-        simulateButtonPress(game, ButtonAction::PLUS_500);
+        simulateButtonPress(game, ButtonAction::PLUS_500, 3);
         
         // Start banking
         simulateButtonPress(game, ButtonAction::BANK);

--- a/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
@@ -62,9 +62,7 @@ void test_TurnLifecycle_StandardTurn() {
     setupGameWithPlayers(game, 4);
 
     // Simulate scoring 1500 (3 x 500)
-    simulateButtonPress(game, ButtonAction::PLUS_500);
-    simulateButtonPress(game, ButtonAction::PLUS_500);
-    simulateButtonPress(game, ButtonAction::PLUS_500);
+    simulateButtonPress(game, ButtonAction::PLUS_500, 3);
     
     // Start banking
     simulateButtonPress(game, ButtonAction::BANK);
@@ -86,8 +84,7 @@ void test_TurnLifecycle_RoundRobin() {
     setupGameWithPlayers(game, 4);
 
     for (int i = 0; i < 4; i++) {
-        simulateButtonPress(game, ButtonAction::PLUS_500);
-        simulateButtonPress(game, ButtonAction::PLUS_500);
+        simulateButtonPress(game, ButtonAction::PLUS_500, 2);
         
         // Start banking
         simulateButtonPress(game, ButtonAction::BANK);
@@ -106,8 +103,7 @@ void test_TurnLifecycle_RoundRobin() {
 void test_TurnLifecycle_ClearButton() {
     Game game;
     setupGameWithPlayers(game, 4);
-    simulateButtonPress(game, ButtonAction::PLUS_500);
-    simulateButtonPress(game, ButtonAction::PLUS_500);
+    simulateButtonPress(game, ButtonAction::PLUS_500, 2);
     simulateButtonPress(game, ButtonAction::CLEAR);
 
     TEST_ASSERT_EQUAL_INT(0, game.state.atRiskScore);

--- a/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
@@ -107,9 +107,7 @@ void test_PlayerSelection_MaxPlayers() {
     simulateButtonPress(game, ButtonAction::FARKLE);
 
     // Add 8 players
-    for (int i = 0; i < 8; ++i) {
-        simulateButtonPress(game, ButtonAction::BANK);
-    }
+    simulateButtonPress(game, ButtonAction::BANK, 8);
 
     TEST_ASSERT_EQUAL_INT(8, game.state.players.size());
     TEST_ASSERT_TRUE(game.grid.isMaxPlayersReached());

--- a/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.cpp
@@ -32,8 +32,7 @@ void test_WaitingPhase_ScoreCorrection() {
     setupGameWithPlayers(game, 4);
 
     // Add some score
-    simulateButtonPress(game, ButtonAction::PLUS_500);
-    simulateButtonPress(game, ButtonAction::PLUS_500);
+    simulateButtonPress(game, ButtonAction::PLUS_500, 2);
     TEST_ASSERT_EQUAL_INT(1000, game.state.atRiskScore);
 
     // Simulate pressing CLEAR

--- a/src/farkle/test/test_game_logic/small_tests/test_multi_press.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_multi_press.cpp
@@ -1,0 +1,23 @@
+#include "test_multi_press.h"
+#include "../test_utils.h"
+#include <unity.h>
+
+void test_simulate_button_press_count() {
+    Game game;
+    setupGameWithPlayers(game, 2); // 2 players
+
+    // Player 1 is active.
+    // Simulate pressing PLUS_500 twice.
+    // Expected: Current roll score increases by 1000.
+
+    // This call uses the new feature: count = 2.
+    // If implementation is not updated, it treats '2' as 'time', so only 1 press happens -> 500 points.
+    // If implementation is updated, it presses twice -> 1000 points.
+    simulateButtonPress(game, ButtonAction::PLUS_500, 2);
+
+    TEST_ASSERT_EQUAL_INT(1000, game.state.atRiskScore);
+}
+
+void run_multi_press_tests() {
+    RUN_TEST(test_simulate_button_press_count);
+}

--- a/src/farkle/test/test_game_logic/small_tests/test_multi_press.h
+++ b/src/farkle/test/test_game_logic/small_tests/test_multi_press.h
@@ -1,0 +1,6 @@
+#ifndef TEST_MULTI_PRESS_H
+#define TEST_MULTI_PRESS_H
+
+void run_multi_press_tests();
+
+#endif // TEST_MULTI_PRESS_H

--- a/src/farkle/test/test_game_logic/test_main.cpp
+++ b/src/farkle/test/test_game_logic/test_main.cpp
@@ -9,6 +9,7 @@
 #include "medium_tests/test_turn_lifecycle.h"
 #include "medium_tests/test_conditional_at_risk_display.h"
 #include "medium_tests/test_tie_breaking.h"
+#include "small_tests/test_multi_press.h"
 
 void setUp(void) {
     // set up tear down functions that are required by unity
@@ -29,6 +30,7 @@ void test_runner() {
     run_turn_lifecycle_tests();
     run_display_logic_tests();
     run_tie_breaking_tests();
+    run_multi_press_tests();
 }
 
 int main() {

--- a/src/farkle/test/test_game_logic/test_utils.cpp
+++ b/src/farkle/test/test_game_logic/test_utils.cpp
@@ -1,10 +1,12 @@
 #include "test_utils.h"
 #include "Arduino.h"
 
-void simulateButtonPress(Game& game, ButtonAction action, unsigned long advance_time_millis) {
-    game.controlPad.press(action);
-    advance_millis(advance_time_millis);
-    game.loop();
+void simulateButtonPress(Game& game, ButtonAction action, int count, unsigned long advance_time_millis) {
+    for (int i = 0; i < count; ++i) {
+        game.controlPad.press(action);
+        advance_millis(advance_time_millis);
+        game.loop();
+    }
 }
 
 void simulateRotation(Game& game, int delta, unsigned long advance_time_millis) {

--- a/src/farkle/test/test_game_logic/test_utils.h
+++ b/src/farkle/test/test_game_logic/test_utils.h
@@ -4,7 +4,7 @@
 #include "Game.h"
 #include "Input.h"
 
-void simulateButtonPress(Game& game, ButtonAction action, unsigned long advance_time_millis = 10);
+void simulateButtonPress(Game& game, ButtonAction action, int count = 1, unsigned long advance_time_millis = 10);
 void simulateRotation(Game& game, int delta, unsigned long advance_time_millis = 10);
 // Removed simulateScore
 void simulateNoAction(Game& game, unsigned long advance_time_millis = 10);


### PR DESCRIPTION
Implemented an overload for `simulateButtonPress` that accepts a `count` parameter to trigger multiple button presses in sequence, simplifying test code. Verified with a new test case and existing regression tests.

---
*PR created automatically by Jules for task [10913448844726420817](https://jules.google.com/task/10913448844726420817) started by @gwenrich136*