### PR TITLE
refactor: rename atRiskScore to blinkingScore in LedProgressGrid

### DIFF
--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
@@ -144,7 +144,7 @@ void LedProgressGrid::renderPlayerRows(PlayerRows rows, uint16_t hue, float rati
     }
 }
 
-void LedProgressGrid::update(const int* scores, int playerCount, int currentPlayerIndex, int atRiskScore) {
+void LedProgressGrid::update(const int* scores, int playerCount, int currentPlayerIndex, int blinkingScore) {
   if (playerCount < _playerCount) {
     return;
   }
@@ -156,7 +156,7 @@ void LedProgressGrid::update(const int* scores, int playerCount, int currentPlay
   for (int i = 0; i < _playerCount; ++i) {
     int potentialScore = scores[i];
     if (i == currentPlayerIndex) {
-        potentialScore += atRiskScore;
+        potentialScore += blinkingScore;
     }
     if (potentialScore > highestScore) {
       highestScore = potentialScore;
@@ -178,7 +178,7 @@ void LedProgressGrid::update(const int* scores, int playerCount, int currentPlay
   }
 
   currentState.currentPlayerIndex = currentPlayerIndex;
-  currentState.atRiskScore = atRiskScore;
+  currentState.blinkingScore = blinkingScore;
   currentState.isBlinkOn = _isBlinkOn;
   currentState.playerCount = _playerCount;
   currentState.maxScore = _maxScore;
@@ -194,9 +194,9 @@ void LedProgressGrid::update(const int* scores, int playerCount, int currentPlay
     PlayerRows rows = PlayerLayout::getMapping(_playerCount, playerIdx);
     
     int scoreToDraw = scores[playerIdx];
-    bool showingRisk = (playerIdx == currentPlayerIndex && atRiskScore > 0 && _isBlinkOn);
-    if (showingRisk) {
-      scoreToDraw += atRiskScore;
+    bool showingBlink = (playerIdx == currentPlayerIndex && blinkingScore > 0 && _isBlinkOn);
+    if (showingBlink) {
+      scoreToDraw += blinkingScore;
     }
 
     float ratioToDraw = (float)scoreToDraw / _maxScore;

--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.h
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.h
@@ -18,7 +18,7 @@ public:
     DisplayMode mode = DisplayMode::NONE;
     int scores[MAX_PLAYERS] = {0};
     int currentPlayerIndex = -1;
-    int atRiskScore = -1;
+    int blinkingScore = -1;
     bool isBlinkOn = false;
     bool isPlayerPending = false;
     int playerCount = 0;
@@ -29,7 +29,7 @@ public:
       if (isDirty || other.isDirty ||
           mode != other.mode ||
           currentPlayerIndex != other.currentPlayerIndex ||
-          atRiskScore != other.atRiskScore ||
+          blinkingScore != other.blinkingScore ||
           isBlinkOn != other.isBlinkOn ||
           isPlayerPending != other.isPlayerPending ||
           playerCount != other.playerCount ||
@@ -53,7 +53,7 @@ public:
   bool isMaxPlayersReached();
   void reset();
   void clear();
-  void update(const int* scores, int playerCount, int currentPlayerIndex, int atRiskScore);
+  void update(const int* scores, int playerCount, int currentPlayerIndex, int blinkingScore);
   void displayPlayersPregame(bool isPlayerPending);
   int getMaxScore() const { return _maxScore; }
 

--- a/src/farkle/test/mocks/include/LedProgressGrid.h
+++ b/src/farkle/test/mocks/include/LedProgressGrid.h
@@ -10,7 +10,7 @@ public:
     // Captured state for inspection by tests
     std::vector<int> captured_scores;
     int captured_currentPlayerIndex;
-    int captured_atRiskScore;
+    int captured_blinkingScore;
     int player_count;
     bool was_cleared;
     bool was_reset;
@@ -24,7 +24,7 @@ public:
     bool isMaxPlayersReached();
     void reset();
     void clear();
-    void update(const int* scores, int playerCount, int currentPlayerIndex, int atRiskScore);
+    void update(const int* scores, int playerCount, int currentPlayerIndex, int blinkingScore);
     void displayPlayersPregame(bool isPlayerPending);
 };
 

--- a/src/farkle/test/mocks/src/LedProgressGrid.cpp
+++ b/src/farkle/test/mocks/src/LedProgressGrid.cpp
@@ -32,13 +32,13 @@ void LedProgressGrid::clear() {
     was_cleared = true;
 }
 
-void LedProgressGrid::update(const int* scores, int playerCount, int currentPlayerIndex, int atRiskScore) {
+void LedProgressGrid::update(const int* scores, int playerCount, int currentPlayerIndex, int blinkingScore) {
     captured_scores.clear();
     for (int i = 0; i < playerCount; ++i) {
         captured_scores.push_back(scores[i]);
     }
     captured_currentPlayerIndex = currentPlayerIndex;
-    captured_atRiskScore = atRiskScore;
+    captured_blinkingScore = blinkingScore;
 }
 
 void LedProgressGrid::displayPlayersPregame(bool isPlayerPending) {

--- a/src/farkle/test/test_component_led_progress_grid/test_led_progress_grid.cpp
+++ b/src/farkle/test/test_component_led_progress_grid/test_led_progress_grid.cpp
@@ -178,7 +178,7 @@ void test_LedProgressGrid_MaxScore_Exact(void) {
 }
 
 void test_LedProgressGrid_MaxScore_IncludesAtRisk(void) {
-    // Verify that _maxScore takes atRiskScore into account.
+    // Verify that _maxScore takes blinkingScore into account.
     grid->setTargetScore(10000);
     grid->addPlayer();
     std::vector<int> scores = {9000};
@@ -196,15 +196,15 @@ void test_LedProgressGrid_MaxScore_Shrinking(void) {
     grid->update(scores.data(), scores.size(), 0, 0);
     TEST_ASSERT_EQUAL(12000, grid->getMaxScore());
 
-    // Player Farkles, score stays 12000? No, if atRisk was part of it.
-    // Let's use atRisk to grow and then remove it.
+    // Player Farkles, score stays 12000? No, if blinkingScore was part of it.
+    // Let's use blinkingScore to grow and then remove it.
     scores[0] = 10000;
     grid->update(scores.data(), scores.size(), 0, 2000); // 10000 + 2000 = 12000
     TEST_ASSERT_EQUAL(12000, grid->getMaxScore());
 
-    // Now Farkle (atRisk becomes 0)
+    // Now Farkle (blinkingScore becomes 0)
     grid->update(scores.data(), scores.size(), 0, 0);
-    // Should shrink back to targetScore (10000) because banked is 10000 and atRisk is 0.
+    // Should shrink back to targetScore (10000) because banked is 10000 and blinkingScore is 0.
     TEST_ASSERT_EQUAL(10000, grid->getMaxScore());
 }
 


### PR DESCRIPTION
Renamed `atRiskScore` to `blinkingScore` within the `LedProgressGrid` component to better reflect generic display behavior and decouple it from specific game logic phrasing.

- Updated `LedProgressGrid::update` signature in `.h` and `.cpp`
- Updated `State::atRiskScore` struct property to `blinkingScore`
- Updated mock header and cpp files
- Verified via `pio test` on both native and component environments that all logic remains a "no-op" for the broader game state.

---
*PR created automatically by Jules for task [17611025463241319065](https://jules.google.com/task/17611025463241319065) started by @gwenrich136*