### PR TITLE
feat: Refactor LedProgressGrid animations to only blink in WaitingPhase

### DIFF
--- a/design/IN_GAME_PHASES.md
+++ b/design/IN_GAME_PHASES.md
@@ -75,6 +75,11 @@ This category handles user input for scoring, provides feedback through animatio
     -   **WaitingPhase:** The current player's LED blinks (White/Yellow/Red) to indicate it is their turn to act.
     -   **Banking/Farkling Phases:** The current player's LED becomes solid (like other players) during animations, reducing visual noise.
     -   **PenaltyFarklingPhase:** Triggers a special alternating animation during the penalty sequence.
+-   **LED Progress Grid Animations:**
+    -   **WaitingPhase:** Shows the banked score and blinks the potential score (`atRiskScore`).
+    -   **BankingPhase:** Shows only the banked score growing smoothly. No blinking score.
+    -   **FarklingPhase:** Shows the potential score (banked + `atRiskScore`) shrinking smoothly back to the banked score. No blinking score.
+    -   **PenaltyFarklingPhase:** Shows only the banked score shrinking smoothly. No blinking score.
 
 ### Score Display Behavior
 - **Default (InGamePhase):** If `atRiskScore` is 0, the display is cleared.

--- a/src/farkle/include/GamePhase.h
+++ b/src/farkle/include/GamePhase.h
@@ -61,6 +61,10 @@ protected:
     virtual void updateWarningLights(const GameState& state, const Displays& displays);
     virtual void updateTextDisplay(const GameState& state, const Displays& displays);
 
+    // Virtual hooks for calculating scores displayed on the Progress Grid
+    virtual int getGridScoreForPlayer(const GameState& state, int playerIndex) const;
+    virtual int getBlinkingScore(const GameState& state) const;
+
     // Helper to calculate the highest score among all players
     int calculateLeadingScore(const GameState& state);
 

--- a/src/farkle/include/phases/FarklingPhase.h
+++ b/src/farkle/include/phases/FarklingPhase.h
@@ -9,6 +9,9 @@ public:
     virtual void onEnter(GameState& state) override;
     virtual GamePhase* update(Game& game, GameState& state, GameInput input, unsigned long deltaTime) override;
 
+protected:
+    virtual int getGridScoreForPlayer(const GameState& state, int playerIndex) const override;
+
 private:
     float scoreMoveAccumulator;
 };

--- a/src/farkle/include/phases/WaitingPhase.h
+++ b/src/farkle/include/phases/WaitingPhase.h
@@ -12,6 +12,7 @@ public:
 protected:
     virtual void updateAtRiskScoreDisplay(const GameState& state, const Displays& displays) override;
     virtual void updateWarningLights(const GameState& state, const Displays& displays) override;
+    virtual int getBlinkingScore(const GameState& state) const override;
 };
 
 #endif

--- a/src/farkle/src/phases/FarklingPhase.cpp
+++ b/src/farkle/src/phases/FarklingPhase.cpp
@@ -40,3 +40,11 @@ GamePhase* FarklingPhase::update(Game& game, GameState& state, GameInput input, 
 
     return this;
 }
+
+int FarklingPhase::getGridScoreForPlayer(const GameState& state, int playerIndex) const {
+    if (playerIndex == state.currentPlayerIndex) {
+        // Show potential score falling back to banked score
+        return state.players[playerIndex].score + state.atRiskScore;
+    }
+    return InGamePhase::getGridScoreForPlayer(state, playerIndex);
+}

--- a/src/farkle/src/phases/InGamePhase.cpp
+++ b/src/farkle/src/phases/InGamePhase.cpp
@@ -35,15 +35,8 @@ void InGamePhase::updateCompetitionScoreDisplay(const GameState& state, const Di
 }
 
 void InGamePhase::updateProgressGrid(const GameState& state, const Displays& displays) {
-    // For subclasses where the score calculation logic is dynamic and does not simply increment
-    // scoresVersion, we will always recalculate the grid. To be safe, we just rebuild the scores array
-    // when finalRoundTriggered is active or when scoresVersion changes, but for simplicity we should
-    // probably just recalculate it each frame if we use state.atRiskScore in the grid score for FarklingPhase
-    // because atRiskScore doesn't bump scoresVersion.
-    // However, the animation runs many frames.
-
-    // Actually, FarklingPhase drains atRiskScore every frame. atRiskScore isn't tracked by scoresVersion.
-    // So we must rebuild the m_scores array if it's dependent on atRiskScore or if scoresVersion changed.
+    // Rebuild the m_scores array every frame because animation phases (like FarklingPhase)
+    // drain atRiskScore continuously, and atRiskScore is not tracked by scoresVersion.
     m_scores.clear();
     for (size_t i = 0; i < state.players.size(); ++i) {
         m_scores.push_back(getGridScoreForPlayer(state, i));

--- a/src/farkle/src/phases/InGamePhase.cpp
+++ b/src/farkle/src/phases/InGamePhase.cpp
@@ -35,14 +35,30 @@ void InGamePhase::updateCompetitionScoreDisplay(const GameState& state, const Di
 }
 
 void InGamePhase::updateProgressGrid(const GameState& state, const Displays& displays) {
-    if (m_scores.size() != state.players.size() || m_lastScoresVersion != state.scoresVersion) {
-        m_scores.clear();
-        for (const auto& player : state.players) {
-            m_scores.push_back(player.score);
-        }
-        m_lastScoresVersion = state.scoresVersion;
+    // For subclasses where the score calculation logic is dynamic and does not simply increment
+    // scoresVersion, we will always recalculate the grid. To be safe, we just rebuild the scores array
+    // when finalRoundTriggered is active or when scoresVersion changes, but for simplicity we should
+    // probably just recalculate it each frame if we use state.atRiskScore in the grid score for FarklingPhase
+    // because atRiskScore doesn't bump scoresVersion.
+    // However, the animation runs many frames.
+
+    // Actually, FarklingPhase drains atRiskScore every frame. atRiskScore isn't tracked by scoresVersion.
+    // So we must rebuild the m_scores array if it's dependent on atRiskScore or if scoresVersion changed.
+    m_scores.clear();
+    for (size_t i = 0; i < state.players.size(); ++i) {
+        m_scores.push_back(getGridScoreForPlayer(state, i));
     }
-    displays.grid.update(m_scores.data(), (int)m_scores.size(), state.currentPlayerIndex, state.atRiskScore);
+    m_lastScoresVersion = state.scoresVersion;
+
+    displays.grid.update(m_scores.data(), (int)m_scores.size(), state.currentPlayerIndex, getBlinkingScore(state));
+}
+
+int InGamePhase::getGridScoreForPlayer(const GameState& state, int playerIndex) const {
+    return state.players[playerIndex].score;
+}
+
+int InGamePhase::getBlinkingScore(const GameState& state) const {
+    return 0; // Default behavior is no blinking score
 }
 
 void InGamePhase::updateWarningLights(const GameState& state, const Displays& displays) {

--- a/src/farkle/src/phases/WaitingPhase.cpp
+++ b/src/farkle/src/phases/WaitingPhase.cpp
@@ -70,3 +70,7 @@ void WaitingPhase::updateWarningLights(const GameState& state, const Displays& d
     // In WaitingPhase, we WANT the current player to blink (turn indicator)
     displays.farkleLights.update(farkleCounts, count, state.currentPlayerIndex, isBlinkOn);
 }
+
+int WaitingPhase::getBlinkingScore(const GameState& state) const {
+    return state.atRiskScore;
+}

--- a/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.cpp
@@ -107,6 +107,23 @@ void test_BankingPhase_FinalRoundBlinking() {
     TEST_ASSERT_TRUE(game.scoreDisplay.captured_blinks[ScoreDisplay::DisplayType::COMPETITION_SCORE]);
 }
 
+// Verifies that the LedProgressGrid receives the correct scores and NO blinking score during the BankingPhase.
+void test_BankingPhase_GridAnimationScores() {
+    Game game;
+    setupGameWithPlayers(game, 2);
+    game.state.players[0].score = 1000;
+    game.state.atRiskScore = 500;
+    game.currentPhase = game.getPhase<BankingPhase>();
+
+    Displays displays(game.scoreDisplay, game.grid, game.farkleLights, game.oled);
+    game.currentPhase->display(game.state, displays);
+
+    // It should display the player's base score (1000), not added to atRiskScore.
+    TEST_ASSERT_EQUAL_INT(1000, game.grid.captured_scores[0]);
+    // The blinking score should be 0.
+    TEST_ASSERT_EQUAL_INT(0, game.grid.captured_blinkingScore);
+}
+
 void run_banking_phase_tests() {
     RUN_TEST(test_BankingPhase_AnimationMath);
     RUN_TEST(test_BankingPhase_ZeroFloorSafety);
@@ -115,4 +132,5 @@ void run_banking_phase_tests() {
     RUN_TEST(test_BankingPhase_FarkleResetOnEnter);
     RUN_TEST(test_BankingPhase_LightsOffDuringAnimation);
     RUN_TEST(test_BankingPhase_FinalRoundBlinking);
+    RUN_TEST(test_BankingPhase_GridAnimationScores);
 }

--- a/src/farkle/test/test_game_logic/small_tests/test_FarklingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_FarklingPhase.cpp
@@ -107,6 +107,23 @@ void test_FarklingPhase_FinalRoundBlinking() {
     TEST_ASSERT_TRUE(game.scoreDisplay.captured_blinks[ScoreDisplay::DisplayType::COMPETITION_SCORE]);
 }
 
+// Verifies that the LedProgressGrid receives the potential score as the base score, and NO blinking score during the FarklingPhase.
+void test_FarklingPhase_GridAnimationScores() {
+    Game game;
+    setupGameWithPlayers(game, 2);
+    game.state.players[0].score = 1000;
+    game.state.atRiskScore = 500;
+    game.currentPhase = game.getPhase<FarklingPhase>();
+
+    Displays displays(game.scoreDisplay, game.grid, game.farkleLights, game.oled);
+    game.currentPhase->display(game.state, displays);
+
+    // It should display the player's potential score (1500) falling back to base.
+    TEST_ASSERT_EQUAL_INT(1500, game.grid.captured_scores[0]);
+    // The blinking score should be 0.
+    TEST_ASSERT_EQUAL_INT(0, game.grid.captured_blinkingScore);
+}
+
 void run_farkling_phase_tests() {
     RUN_TEST(test_FarklingPhase_AnimationMath);
     RUN_TEST(test_FarklingPhase_ZeroFloorSafety);
@@ -115,4 +132,5 @@ void run_farkling_phase_tests() {
     RUN_TEST(test_FarklingPhase_NoHarmNoFoul_NoIncrement);
     RUN_TEST(test_FarklingPhase_IncrementWithPoints);
     RUN_TEST(test_FarklingPhase_FinalRoundBlinking);
+    RUN_TEST(test_FarklingPhase_GridAnimationScores);
 }

--- a/src/farkle/test/test_game_logic/small_tests/test_PenaltyFarklingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PenaltyFarklingPhase.cpp
@@ -119,6 +119,23 @@ void test_PenaltyFarklingPhase_FinalRoundBlinking() {
     TEST_ASSERT_TRUE(game.scoreDisplay.captured_blinks[ScoreDisplay::DisplayType::COMPETITION_SCORE]);
 }
 
+// Verifies that the LedProgressGrid receives the correct scores and NO blinking score during the PenaltyFarklingPhase.
+void test_PenaltyFarklingPhase_GridAnimationScores() {
+    Game game;
+    setupGameWithPlayers(game, 2);
+    game.state.players[0].score = 1000;
+    game.currentPhase = game.getPhase<PenaltyFarklingPhase>();
+    game.currentPhase->onEnter(game.state);
+
+    Displays displays(game.scoreDisplay, game.grid, game.farkleLights, game.oled);
+    game.currentPhase->display(game.state, displays);
+
+    // It should display the player's base score.
+    TEST_ASSERT_EQUAL_INT(1000, game.grid.captured_scores[0]);
+    // The blinking score should be 0.
+    TEST_ASSERT_EQUAL_INT(0, game.grid.captured_blinkingScore);
+}
+
 void run_penalty_farkling_phase_tests() {
     RUN_TEST(test_PenaltyFarklingPhase_AnimationMath);
     RUN_TEST(test_PenaltyFarklingPhase_BlinkParameter);
@@ -126,4 +143,5 @@ void run_penalty_farkling_phase_tests() {
     RUN_TEST(test_PenaltyFarklingPhase_InputSpamming);
     RUN_TEST(test_PenaltyFarklingPhase_ManualAdvance);
     RUN_TEST(test_PenaltyFarklingPhase_FinalRoundBlinking);
+    RUN_TEST(test_PenaltyFarklingPhase_GridAnimationScores);
 }

--- a/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.cpp
@@ -100,6 +100,23 @@ void test_WaitingPhase_FinalRoundBlinking() {
     TEST_ASSERT_TRUE(game.scoreDisplay.captured_blinks[ScoreDisplay::DisplayType::COMPETITION_SCORE]);
 }
 
+// Verifies that the LedProgressGrid receives the correct scores and YES blinking score during the WaitingPhase.
+void test_WaitingPhase_GridAnimationScores() {
+    Game game;
+    setupGameWithPlayers(game, 2);
+    game.state.players[0].score = 1000;
+    game.state.atRiskScore = 500;
+    game.currentPhase = game.getPhase<WaitingPhase>();
+
+    Displays displays(game.scoreDisplay, game.grid, game.farkleLights, game.oled);
+    game.currentPhase->display(game.state, displays);
+
+    // It should display the player's base score.
+    TEST_ASSERT_EQUAL_INT(1000, game.grid.captured_scores[0]);
+    // The blinking score should be the atRiskScore.
+    TEST_ASSERT_EQUAL_INT(500, game.grid.captured_blinkingScore);
+}
+
 void run_waiting_phase_tests() {
     RUN_TEST(test_WaitingPhase_ScoreAccumulation);
     RUN_TEST(test_WaitingPhase_ScoreCorrection);
@@ -107,4 +124,5 @@ void run_waiting_phase_tests() {
     RUN_TEST(test_WaitingPhase_TransitionToFarkling);
     RUN_TEST(test_WaitingPhase_TransitionToPenaltyFarkling);
     RUN_TEST(test_WaitingPhase_FinalRoundBlinking);
+    RUN_TEST(test_WaitingPhase_GridAnimationScores);
 }


### PR DESCRIPTION
Refactored `InGamePhase` to use virtual methods `getGridScoreForPlayer` and `getBlinkingScore` for `LedProgressGrid` updates. Updated `WaitingPhase` to be the only phase that sets the blinking score. `FarklingPhase`, `BankingPhase`, and `PenaltyFarklingPhase` now smoothly animate by directly including the potential/penalty scores in the base score array sent to the grid. All tests and documentation have been updated.

---
*PR created automatically by Jules for task [10409859341091092255](https://jules.google.com/task/10409859341091092255) started by @gwenrich136*