### PR TITLE
refactor: Use SELECT button for pre-game setup actions

### DIFF
--- a/design/GENERAL_GAME_PLAY.md
+++ b/design/GENERAL_GAME_PLAY.md
@@ -16,13 +16,13 @@ The game begins by guiding players through setup and configuration.
 -   **Initial State:** The scoreboard asks "Target Score?". The default selection is 10,000.
 -   **Navigation:** Players rotate the dial (Encoder) to increment or decrement the goal in steps of 1,000. The range is clamped between 1,000 and 20,000.
 -   **Visual Feedback:** The `ScoreDisplay` segment for the "Competition Score" updates in real-time to show the currently selected target.
--   **Confirmation:** Pressing either `BANK` (Green), `FARKLE` (Red), or `SELECT` (Encoder Push) confirms the target score and transitions to the "Player Selection" screen.
+-   **Confirmation:** Pressing `SELECT` (Encoder Push) confirms the target score and transitions to the "Player Selection" screen.
 
 ### 1.2 Player Selection
 -   **Initial State:** The scoreboard displays a "Player Selection" screen, presenting a list of pre-stored player names.
 -   **Goal Persistence:** The "Competition Score" segment remains lit with the chosen target score throughout the selection process.
 -   **Navigation:** Players rotate the dial (Encoder) to scroll through the available names. While scrolling, the `LedProgressGrid` visually indicates the "pending player" by blinking the rows that player would occupy with their assigned color.
--   **Selecting a Player:** Pressing the `BANK` (Green) button on a highlighted name adds that player to the game. The player list refreshes, removing the selected player from the available list, and the system remains in the "Player Selection" state, ready for the next player.
+-   **Selecting a Player:** Pressing the `SELECT` (Encoder Push) button on a highlighted name adds that player to the game. The player list refreshes, removing the selected player from the available list, and the system remains in the "Player Selection" state, ready for the next player.
 -   **Player Limit**: Once the maximum number of players is reached (currently 8), the system stops showing a "pending" player and the ability to add more is disabled.
 
 ### 1.2 Player Creation

--- a/design/PRE_GAME_PHASES.md
+++ b/design/PRE_GAME_PHASES.md
@@ -31,7 +31,7 @@ The system follows this sequence:
     1.  **Selection Logic**: Starts at a default of 10,000. Clamped between 1,000 and 20,000.
     2.  **Navigation**: 
         *   **Encoder Rotation**: Increments or decrements `state.targetScore` in steps of 1,000.
-    3.  **Confirmation (BANK, FARKLE, or SELECT)**: 
+    3.  **Confirmation (SELECT)**:
         *   Finalizes the selection by calling `game.setTargetScore(state.targetScore)` to sync hardware (LED Grid).
         *   Returns `game.getPhase<PlayerSelectionPhase>()`.
     4.  **Display Behavior (Hooks)**:
@@ -47,7 +47,7 @@ The system follows this sequence:
     2.  **Navigation**: 
         *   **Encoder Rotation**: Increments or decrements the selection index.
         *   The list of available names is filtered in real-time to exclude names already present in `state.players`.
-    3.  **Adding Players (GREEN/BANK)**: 
+    3.  **Adding Players (SELECT)**:
         *   Checks `game.canAddPlayer()` (which queries `grid.isMaxPlayersReached()`).
         *   If allowed, calls `game.addPlayer(selectedName)`. This updates both the `GameState` and the hardware (color assignment in `LedProgressGrid`).
     4.  **Starting Game (RED/FARKLE)**: 

--- a/src/farkle/src/phases/PlayerSelectionPhase.cpp
+++ b/src/farkle/src/phases/PlayerSelectionPhase.cpp
@@ -32,7 +32,7 @@ GamePhase* PlayerSelectionPhase::update(Game& game, GameState& state, GameInput 
     }
 
     // Handle actions
-    if (input.action == ButtonAction::BANK) {
+    if (input.action == ButtonAction::SELECT) {
         if (game.canAddPlayer()) {
             if (m_availableNames.size() > 0) {
                 game.addPlayer(m_availableNames[m_selectionIndex]);

--- a/src/farkle/src/phases/TargetScoreSelectionPhase.cpp
+++ b/src/farkle/src/phases/TargetScoreSelectionPhase.cpp
@@ -7,7 +7,7 @@ void TargetScoreSelectionPhase::onEnter(GameState& state) {
 }
 
 GamePhase* TargetScoreSelectionPhase::update(Game& game, GameState& state, GameInput input, unsigned long deltaTime) {
-    if (input.action == ButtonAction::BANK || input.action == ButtonAction::FARKLE) {
+    if (input.action == ButtonAction::SELECT) {
         game.setTargetScore(state.targetScore);
         return game.getPhase<PlayerSelectionPhase>();
     }

--- a/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
@@ -25,7 +25,7 @@ void test_TurnLifecycle_FullSetupAndTurn() {
     TEST_ASSERT_EQUAL_STRING("10,000", game.oled.captured_item.c_str());
 
     // Transition to Player Selection
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // 2. Initial selection state (Geewee selected)
     TEST_ASSERT_EQUAL_STRING("Add Player", game.oled.captured_title.c_str());
@@ -36,7 +36,7 @@ void test_TurnLifecycle_FullSetupAndTurn() {
     simulateRotation(game, 1); // Coach
 
     // 4. Add Coach
-    simulateButtonPress(game, ButtonAction::BANK);
+    simulateButtonPress(game, ButtonAction::SELECT);
     TEST_ASSERT_EQUAL_INT(1, game.state.players.size());
     TEST_ASSERT_EQUAL_STRING("Coach", game.state.players[0].name.c_str());
 
@@ -44,7 +44,7 @@ void test_TurnLifecycle_FullSetupAndTurn() {
     // After adding Coach (index 2), Sheshe is now at index 2.
     // Alex is at index 3. So one Rotation is needed.
     simulateRotation(game, 1); // Alex
-    simulateButtonPress(game, ButtonAction::BANK);
+    simulateButtonPress(game, ButtonAction::SELECT);
     TEST_ASSERT_EQUAL_INT(2, game.state.players.size());
     TEST_ASSERT_EQUAL_STRING("Alex", game.state.players[1].name.c_str());
 

--- a/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
@@ -10,7 +10,7 @@ void test_PlayerSelection_InitialState() {
     game.setup();
 
     // Transition to PlayerSelectionPhase
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Should be in PlayerSelectionPhase
     TEST_ASSERT_EQUAL_STRING("Add Player", game.oled.captured_title.c_str());
@@ -22,7 +22,7 @@ void test_PlayerSelection_InitialState() {
 void test_PlayerSelection_Cycling() {
     Game game;
     game.setup();
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Next name
     simulateRotation(game, 1);
@@ -41,19 +41,23 @@ void test_PlayerSelection_Cycling() {
     TEST_ASSERT_EQUAL_STRING("Geewee", game.oled.captured_item.c_str());
 }
 
-// Verifies that pressing BANK adds the selected name and the selection "stays in place" (shifts to next name).
+// Verifies that pressing SELECT adds the selected name and the selection "stays in place" (shifts to next name).
 void test_PlayerSelection_AddPlayer() {
     Game game;
     game.setup();
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Navigate to Sammy (index 1)
     simulateRotation(game, 1);
     TEST_ASSERT_EQUAL_STRING("Sammy", game.oled.captured_item.c_str());
 
-    // Add Sammy. List becomes: Geewee, Coach, Sheshe, ...
-    // index 1 should now point to "Coach"
+    // Press BANK should not add
     simulateButtonPress(game, ButtonAction::BANK);
+    TEST_ASSERT_EQUAL_INT(0, game.state.players.size());
+
+    // Add Sammy with SELECT. List becomes: Geewee, Coach, Sheshe, ...
+    // index 1 should now point to "Coach"
+    simulateButtonPress(game, ButtonAction::SELECT);
     TEST_ASSERT_EQUAL_INT(1, game.state.players.size());
     TEST_ASSERT_EQUAL_STRING("Sammy", game.state.players[0].name.c_str());
 
@@ -64,14 +68,14 @@ void test_PlayerSelection_AddPlayer() {
 void test_PlayerSelection_Filtering() {
     Game game;
     game.setup();
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Add Geewee (index 0)
-    simulateButtonPress(game, ButtonAction::BANK);
+    simulateButtonPress(game, ButtonAction::SELECT);
     // index 0 is now Sammy
 
     // Add Sammy (index 0)
-    simulateButtonPress(game, ButtonAction::BANK);
+    simulateButtonPress(game, ButtonAction::SELECT);
     // index 0 is now Coach
 
     TEST_ASSERT_EQUAL_INT(2, game.state.players.size());
@@ -87,11 +91,12 @@ void test_PlayerSelection_TransitionValidation() {
     game.setup();
 
     // Cannot start with 0 players
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT); // Transition from TargetScore to PlayerSelection
+    simulateButtonPress(game, ButtonAction::FARKLE); // Try to start with 0
     TEST_ASSERT_EQUAL_STRING("Add Player", game.oled.captured_title.c_str());
 
     // Add 1 player
-    simulateButtonPress(game, ButtonAction::BANK);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Now can start
     simulateButtonPress(game, ButtonAction::FARKLE);
@@ -104,17 +109,17 @@ void test_PlayerSelection_TransitionValidation() {
 void test_PlayerSelection_MaxPlayers() {
     Game game;
     game.setup();
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Add 8 players
-    simulateButtonPress(game, ButtonAction::BANK, 8);
+    simulateButtonPress(game, ButtonAction::SELECT, 8);
 
     TEST_ASSERT_EQUAL_INT(8, game.state.players.size());
     TEST_ASSERT_TRUE(game.grid.isMaxPlayersReached());
     TEST_ASSERT_EQUAL_STRING("ROSTER FULL", game.oled.captured_message.c_str());
 
     // Try to add one more
-    simulateButtonPress(game, ButtonAction::BANK);
+    simulateButtonPress(game, ButtonAction::SELECT);
     TEST_ASSERT_EQUAL_INT(8, game.state.players.size());
 }
 
@@ -122,7 +127,7 @@ void test_PlayerSelection_MaxPlayers() {
 void test_PlayerSelection_AddLastPlayerWraps() {
     Game game;
     game.setup();
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Pool size is 9. Add first 8 players one by one, but always selecting the LAST one.
     // names: 0, 1, 2, 3, 4, 5, 6, 7, 8
@@ -132,7 +137,7 @@ void test_PlayerSelection_AddLastPlayerWraps() {
     TEST_ASSERT_EQUAL_STRING("Andrea", game.oled.captured_item.c_str());
 
     // Add Andrea. List size becomes 8. Index 8 is out of bounds. Should wrap to 0 (Geewee).
-    simulateButtonPress(game, ButtonAction::BANK);
+    simulateButtonPress(game, ButtonAction::SELECT);
     TEST_ASSERT_EQUAL_STRING("Geewee", game.oled.captured_item.c_str());
 }
 

--- a/src/farkle/test/test_game_logic/small_tests/test_TargetScoreSelectionPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_TargetScoreSelectionPhase.cpp
@@ -65,7 +65,7 @@ void test_TargetScoreSelection_Clamping() {
     TEST_ASSERT_EQUAL_INT(20000, game.state.targetScore);
 }
 
-// Verifies that pressing BANK or FARKLE transitions to PlayerSelectionPhase.
+// Verifies that pressing SELECT transitions to PlayerSelectionPhase, and BANK/FARKLE do not.
 void test_TargetScoreSelection_Transition() {
     Game game;
     game.setup();
@@ -76,15 +76,18 @@ void test_TargetScoreSelection_Transition() {
     }
     TEST_ASSERT_EQUAL_INT(5000, game.state.targetScore);
 
-    // Transition with BANK
+    // Transition with BANK should do nothing
     simulateButtonPress(game, ButtonAction::BANK);
+    TEST_ASSERT_EQUAL_STRING("Target Score", game.oled.captured_title.c_str());
+
+    // Transition with FARKLE should do nothing
+    simulateButtonPress(game, ButtonAction::FARKLE);
+    TEST_ASSERT_EQUAL_STRING("Target Score", game.oled.captured_title.c_str());
+
+    // Transition with SELECT
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Should be in PlayerSelectionPhase
-    TEST_ASSERT_EQUAL_STRING("Add Player", game.oled.captured_title.c_str());
-
-    // Reset and test transition with FARKLE
-    game.setup();
-    simulateButtonPress(game, ButtonAction::FARKLE);
     TEST_ASSERT_EQUAL_STRING("Add Player", game.oled.captured_title.c_str());
 }
 

--- a/src/farkle/test/test_game_logic/test_utils.cpp
+++ b/src/farkle/test/test_game_logic/test_utils.cpp
@@ -19,7 +19,7 @@ void setupGameWithPlayers(Game& game, int numPlayers) {
     game.setup();
 
     // 1. Transition from TargetScoreSelectionPhase to PlayerSelectionPhase
-    simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateButtonPress(game, ButtonAction::SELECT);
 
     // Names from the pool to be consistent
     const char* names[] = {"Geewee", "Sammy", "Coach", "Sheshe", "Alex", "Tigre", "Pepa", "Fred", "Andrea"};


### PR DESCRIPTION
This pull request updates the pre-game setup phases to make use of the new rotary encoder push button (`SELECT`).

In pull request #121, the ControlPad was revamped, but mapping the rotary encoder's push button was de-scoped. This PR integrates `SELECT` as the primary enter/confirmation button for screen navigation during setup:

1. **Target Score Selection:** The target score is now exclusively confirmed by pressing the `SELECT` button, advancing the game to player selection. Pressing `BANK` or `FARKLE` on this screen now intentionally does nothing.
2. **Player Selection:** Adding a new player to the game roster is now exclusively handled by pressing the `SELECT` button, replacing the previous `BANK` functionality. Pressing `BANK` on this screen now does nothing. Pressing `FARKLE` continues to start the game with the selected players.

All relevant unit tests have been updated to test the new button mappings and to assert that the old buttons no longer perform these actions. Design documents (`PRE_GAME_PHASES.md` and `GENERAL_GAME_PLAY.md`) have also been updated to reflect the new expected behavior.

---
*PR created automatically by Jules for task [9092603351807973970](https://jules.google.com/task/9092603351807973970) started by @gwenrich136*