### PR TITLE
Update Penalty Pain Duration to 5 Seconds

### DIFF
--- a/design/GENERAL_GAME_PLAY.md
+++ b/design/GENERAL_GAME_PLAY.md
@@ -75,7 +75,7 @@ The game begins by guiding players through setup and configuration.
 -   **Trigger:** When a player gets their third consecutive farkle in a turn (and has points to lose).
 -   **Penalty:** A player who gets a third consecutive farkle loses 1,000 points, or their entire score if it's less than 1,000.
 -   **Dramatic Animation Sequence:**
-    1.  **"The Pain Sets In" (approx 3 seconds):**
+    1.  **"The Pain Sets In" (approx 5 seconds):**
         *   The `TextDisplay` shows a penalty quip.
         *   The `atRisk` score display flashes the negative penalty amount (e.g., "-1000" or "-850").
         *   The `FarkleWarningLights` begin **alternating** (Yellow/Red) to signal the catastrophe.

--- a/design/IN_GAME_PHASES.md
+++ b/design/IN_GAME_PHASES.md
@@ -61,7 +61,7 @@ This category handles user input for scoring, provides feedback through animatio
         *   Resets the player's `farkle_count` to 0 immediately.
         *   Initializes a phase-local timer/state for the animation sequence.
     2.  **3-Stage Animation (`update()`):**
-        *   **Stage 1: The Pain (0s - 3s):** No score changes. `atRisk` display is set to blink/flash. Warning lights alternate.
+        *   **Stage 1: The Pain (0s - 5s):** No score changes. `atRisk` display is set to blink/flash. Warning lights alternate.
         *   **Stage 2: The Drain:** `atRisk` display stops blinking. Values animate: `atRisk` goes up to 0, Banked score goes down. Warning lights continue alternating.
         *   **Stage 3: The Wait:** Animation complete. Warning lights turn OFF. Wait for button press.
     3.  **Finalize Turn:** Upon button press, call `endTurn(state)` and `return game.getPhase<WaitingPhase>();`.

--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -103,7 +103,7 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_FarklingPhase_NoHarmNoFoul`:** Verifies that if a player has 0 banked points, their `farkle_count` does **not** increment upon farkling.
 
 *   **`test_PenaltyFarklingPhase.cpp`**
-    *   **`test_PenaltyFarklingPhase_Stage1_ThePain`:** Verifies that for the first 3 seconds, the `atRiskScore` flashes/blinks, the `FarkleWarningLights` alternate, and **no points are moved**.
+    *   **`test_PenaltyFarklingPhase_Stage1_ThePain`:** Verifies that for the first 5 seconds, the `atRiskScore` flashes/blinks, the `FarkleWarningLights` alternate, and **no points are moved**.
     *   **`test_PenaltyFarklingPhase_FinalRoundBlinking`:** Verifies that the Competition Score display blinks when `finalRoundTriggered` is true.
     *   **`test_PenaltyFarklingPhase_Stage2_TheDrain`:** Verifies that after the initial delay, points begin to move (inverse banking) while lights continue to alternate.
     *   **`test_PenaltyFarklingPhase_Stage3_TheWait`:** Verifies that once the score is 0, the animation stops, lights turn OFF, and the game waits for a manual advance button.

--- a/src/farkle/src/phases/PenaltyFarklingPhase.cpp
+++ b/src/farkle/src/phases/PenaltyFarklingPhase.cpp
@@ -3,7 +3,7 @@
 #include <algorithm>
 
 // Constants for animation sequence
-const unsigned long PAIN_DURATION = 3000;
+const unsigned long PAIN_DURATION = 5000;
 const float PENALTY_DRAIN_SPEED = 1.0f;
 
 void PenaltyFarklingPhase::onEnter(GameState& state) {
@@ -23,7 +23,7 @@ GamePhase* PenaltyFarklingPhase::update(Game& game, GameState& state, GameInput 
 
     switch (currentStage) {
         case PenaltyStage::THE_PAIN:
-            // Dramatic pause for 3 seconds with blinking score
+            // Dramatic pause for 5 seconds with blinking score
             if (stageTimer >= PAIN_DURATION) {
                 currentStage = PenaltyStage::THE_DRAIN;
             }

--- a/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
+++ b/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
@@ -60,11 +60,11 @@ void test_FullGame_TripleFarkle() {
     TEST_ASSERT_EQUAL_INT(0, game.state.players[0].farkle_count); // Farkle count is reset
 
     // --- Run the penalty animation ---
-    // Needs to cover 3000ms PAIN + 1000ms DRAIN
+    // Needs to cover 5000ms PAIN + 1000ms DRAIN
     GameInput noInput;
     noInput.action = ButtonAction::NONE;
     noInput.rotationDelta = 0;
-    for (int i = 0; i < 450; ++i) {
+    for (int i = 0; i < 650; ++i) {
         game.currentPhase->update(game, game.state, noInput, 10);
     }
     TEST_ASSERT_EQUAL_INT(0, game.state.atRiskScore);

--- a/src/farkle/test/test_game_logic/medium_tests/test_conditional_at_risk_display.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_conditional_at_risk_display.cpp
@@ -63,14 +63,14 @@ void test_DisplayLogic_PenaltyFarklingPhase_ClearsOnlyAtZero() {
     // Enter PenaltyFarklingPhase
     simulateButtonPress(game, ButtonAction::FARKLE);
 
-    // Stage 1: THE_PAIN (0-3s). Verify display is NOT cleared while score is -1000
+    // Stage 1: THE_PAIN (0-5s). Verify display is NOT cleared while score is -1000
     simulateNoAction(game, 1500);
     TEST_ASSERT_EQUAL_INT(-1000, game.scoreDisplay.captured_numbers[ScoreDisplay::DisplayType::AT_RISK_SCORE]);
     TEST_ASSERT_FALSE(game.scoreDisplay.cleared_displays[ScoreDisplay::DisplayType::AT_RISK_SCORE]);
     TEST_ASSERT_TRUE(game.scoreDisplay.captured_blinks[ScoreDisplay::DisplayType::AT_RISK_SCORE]);
 
-    // Advance past THE_PAIN (3 seconds total)
-    simulateNoAction(game, 1501);
+    // Advance past THE_PAIN (5 seconds total)
+    simulateNoAction(game, 3501);
 
     // Stage 2: THE_DRAIN. Verify display is NOT cleared while score is still negative
     // We can just step once and check

--- a/src/farkle/test/test_game_logic/small_tests/test_PenaltyFarklingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PenaltyFarklingPhase.cpp
@@ -7,7 +7,7 @@
 #include "Arduino.h"
 
 // Verifies that the score animation correctly moves points from atRiskScore (negative) to 0
-// and subtracts from the player's score, after the 3-second pause.
+// and subtracts from the player's score, after the 5-second pause.
 void test_PenaltyFarklingPhase_AnimationMath() {
     Game game;
     setupGameWithPlayers(game, 4);
@@ -16,17 +16,17 @@ void test_PenaltyFarklingPhase_AnimationMath() {
     game.state.atRiskScore = -1000;
     game.state.players[0].score = 2000;
 
-    // 1. Stage: THE_PAIN (3000ms)
+    // 1. Stage: THE_PAIN (5000ms)
     // No points should move during this time.
-    for (int i = 0; i < 290; i++) { // 2900ms
+    for (int i = 0; i < 490; i++) { // 4900ms
         simulateNoAction(game);
     }
     TEST_ASSERT_EQUAL_INT(-1000, game.state.atRiskScore);
     TEST_ASSERT_EQUAL_INT(2000, game.state.players[0].score);
 
     // 2. Stage: THE_DRAIN
-    // Advance past 3000ms
-    simulateNoAction(game, 200); // Now at 3100ms
+    // Advance past 5000ms
+    simulateNoAction(game, 200); // Now at 5100ms
 
     // Draining 1000 points at 1pt/ms takes another 1000ms.
     for (int i = 0; i < 150; i++) { // 1500ms more
@@ -48,7 +48,7 @@ void test_PenaltyFarklingPhase_BlinkParameter() {
     simulateNoAction(game, 100); // Still in THE_PAIN
     TEST_ASSERT_TRUE(game.scoreDisplay.captured_blinks[ScoreDisplay::DisplayType::AT_RISK_SCORE]);
 
-    simulateNoAction(game, 3000); // Now in THE_DRAIN or AFTERMATH
+    simulateNoAction(game, 5000); // Now in THE_DRAIN or AFTERMATH
     TEST_ASSERT_FALSE(game.scoreDisplay.captured_blinks[ScoreDisplay::DisplayType::AT_RISK_SCORE]);
 }
 
@@ -61,8 +61,8 @@ void test_PenaltyFarklingPhase_ZeroCeilingSafety() {
     game.state.atRiskScore = -50;
     game.state.players[0].score = 2000;
 
-    // Advance past THE_PAIN (3000ms)
-    simulateNoAction(game, 3010);
+    // Advance past THE_PAIN (5000ms)
+    simulateNoAction(game, 5010);
     // Advance enough time to drain -50.
     simulateNoAction(game, 500);
 
@@ -93,8 +93,8 @@ void test_PenaltyFarklingPhase_ManualAdvance() {
     game.currentPhase->onEnter(game.state);
     game.state.atRiskScore = -100;
     
-    // Advance past THE_PAIN (3000ms)
-    simulateNoAction(game, 3010);
+    // Advance past THE_PAIN (5000ms)
+    simulateNoAction(game, 5010);
     // Advance past THE_DRAIN (100ms)
     simulateNoAction(game, 500);
 


### PR DESCRIPTION
This change increases the duration of the "Pain" stage in the PenaltyFarklingPhase from 3 seconds to 5 seconds. It includes updates to the implementation, design documents, and all relevant test suites to ensure consistency across the codebase.

Fixes #120

---
*PR created automatically by Jules for task [2701788367825647809](https://jules.google.com/task/2701788367825647809) started by @gwenrich136*