### PR TITLE
docs: synchronize testing strategy with existing tests

### DIFF
--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -84,6 +84,8 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_WaitingPhase_ScoreCorrection`:** Verifies that the `atRiskScore` is cleared when the `CLEAR` button is pressed.
     *   **`test_WaitingPhase_TransitionToBanking`:** Verifies that the game transitions to the `BankingPhase` when the `BANK` button is pressed.
     *   **`test_WaitingPhase_TransitionToFarkling`:** Verifies that the game transitions to the `FarklingPhase` when the `FARKLE` button is pressed.
+    *   **`test_WaitingPhase_TransitionToPenaltyFarkling`:** Verifies that PenaltyFarklingPhase IS triggered if the player has 3 consecutive farkles.
+    *   **`test_WaitingPhase_GridAnimationScores`:** Verifies that the LedProgressGrid receives the correct scores and YES blinking score during the WaitingPhase.
 
 *   **`test_BankingPhase.cpp`**
     *   **`test_BankingPhase_AnimationMath`:** Verifies that the score animation correctly moves points from `atRiskScore` to the player's score.
@@ -93,6 +95,7 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_BankingPhase_ManualAdvance`:** Verifies that a button press transitions to the `WaitingPhase` after the banking animation is complete.
     *   **`test_BankingPhase_FarkleResetOnEnter`:** Verifies that the player's consecutive farkle count is reset to 0 immediately upon entering the `BankingPhase`.
     *   **`test_BankingPhase_LightsOffDuringAnimation`:** Verifies that the `FarkleWarningLights` are off during the banking animation as a result of the farkle count reset.
+    *   **`test_BankingPhase_GridAnimationScores`:** Verifies that the LedProgressGrid receives the correct scores and NO blinking score during the BankingPhase.
 
 *   **`test_FarklingPhase.cpp`**
     *   **`test_FarklingPhase_AnimationMath`:** Verifies that the `atRiskScore` drains to 0 but does NOT add to player score.
@@ -100,16 +103,18 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_FarklingPhase_ZeroFloorSafety`:** Verifies that `atRiskScore` does not go negative.
     *   **`test_FarklingPhase_InputSpamming`:** Verifies that button presses are ignored while the farkling animation is in progress.
     *   **`test_FarklingPhase_ManualAdvance`:** Verifies that a button press transitions to the `WaitingPhase` after the animation is complete.
-    *   **`test_FarklingPhase_NoHarmNoFoul`:** Verifies that if a player has 0 banked points, their `farkle_count` does **not** increment upon farkling.
+    *   **`test_FarklingPhase_NoHarmNoFoul_NoIncrement`:** Verifies that if a player has 0 banked points, their `farkle_count` does **not** increment upon farkling.
+    *   **`test_FarklingPhase_IncrementWithPoints`:** Verifies that farkle_count DOES increment if the player has points.
+    *   **`test_FarklingPhase_GridAnimationScores`:** Verifies that the LedProgressGrid receives the potential score as the base score, and NO blinking score during the FarklingPhase.
 
 *   **`test_PenaltyFarklingPhase.cpp`**
-    *   **`test_PenaltyFarklingPhase_Stage1_ThePain`:** Verifies that for the first 5 seconds, the `atRiskScore` flashes/blinks, the `FarkleWarningLights` alternate, and **no points are moved**.
-    *   **`test_PenaltyFarklingPhase_FinalRoundBlinking`:** Verifies that the Competition Score display blinks when `finalRoundTriggered` is true.
-    *   **`test_PenaltyFarklingPhase_Stage2_TheDrain`:** Verifies that after the initial delay, points begin to move (inverse banking) while lights continue to alternate.
-    *   **`test_PenaltyFarklingPhase_Stage3_TheWait`:** Verifies that once the score is 0, the animation stops, lights turn OFF, and the game waits for a manual advance button.
+    *   **`test_PenaltyFarklingPhase_AnimationMath`:** Verifies that the score animation correctly moves points from atRiskScore (negative) to 0 and subtracts from the player's score, after the 5-second pause.
+    *   **`test_PenaltyFarklingPhase_BlinkParameter`:** Verifies that the blink parameter is correctly passed to the ScoreDisplay during THE_PAIN.
     *   **`test_PenaltyFarklingPhase_ZeroCeilingSafety`:** Verifies that `atRiskScore` does not go above 0.
     *   **`test_PenaltyFarklingPhase_InputSpamming`:** Verifies that button presses are ignored during both the "Pain" and "Drain" stages.
     *   **`test_PenaltyFarklingPhase_ManualAdvance`:** Verifies that a button press transitions to the `WaitingPhase` after the animation is complete.
+    *   **`test_PenaltyFarklingPhase_FinalRoundBlinking`:** Verifies that the Competition Score display blinks when `finalRoundTriggered` is true.
+    *   **`test_PenaltyFarklingPhase_GridAnimationScores`:** Verifies that the LedProgressGrid receives the correct scores and NO blinking score during the PenaltyFarklingPhase.
 
 *   **`test_TargetScoreSelectionPhase.cpp`**
     *   **`test_TargetScoreSelection_InitialState`**: Verifies that the phase starts with the default target score (10,000).
@@ -121,6 +126,7 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_PlayerSelection_InitialState`**: Verifies that the phase starts with the first name in the pool and an empty player list (after transitioning from target selection).
     *   **`test_PlayerSelection_Cycling`**: Verifies that `rotationDelta` (Encoder) navigates the filtered name list correctly, including wrapping behavior.
     *   **`test_PlayerSelection_AddPlayer`**: Verifies that pressing **BANK** (Green) adds the selected name to the `GameState`, assigns a color in the `LedProgressGrid`, and removes the name from the selection list.
+    *   **`test_PlayerSelection_Filtering`**: Verifies that multiple added players are all removed from the selection list and index stays valid.
     *   **`test_PlayerSelection_MaxPlayers`**: Verifies that the phase respects the hardware limit by disabling player addition once the `LedProgressGrid` is full (8 players).
     *   **`test_PlayerSelection_TransitionValidation`**: Verifies that pressing **FARKLE** (Red) is ignored if the player list is empty, but successfully transitions to `WaitingPhase` if at least one player exists.
     *   **`test_PlayerSelection_AddLastPlayerWraps`**: Verifies that adding the last name in the filtered pool correctly wraps the selection index back to the first available name (index 0).
@@ -134,6 +140,7 @@ We will structure our tests into three tiers based on scope and complexity. This
 
 *   **`test_turn_lifecycle.cpp`**
     *   **`test_TurnLifecycle_FullSetupAndTurn`**: Enhanced to start in `TargetScoreSelectionPhase`, transition through `PlayerSelectionPhase`, add specific players, and verify that those specific players are the ones active during the `WaitingPhase`.
+    *   **`test_TurnLifecycle_StandardTurn`**: Verifies that a standard turn correctly banks the score and advances to the next player.
     *   **`test_TurnLifecycle_RoundRobin`**: Verifies that the game correctly cycles through the dynamic list of players created during setup.
     *   **`test_TurnLifecycle_ClearButton`**: Verifies that the clear button resets the `atRiskScore` to 0.
 
@@ -149,6 +156,7 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_DisplayLogic_FarklingPhase_ClearsZero`:** Verifies that in `FarklingPhase`, an `atRiskScore` of 0 results in the display being cleared.
     *   **`test_DisplayLogic_PenaltyFarklingPhase_ClearsOnlyAtZero`:** Verifies that in `PenaltyFarklingPhase`, the at-risk display remains visible while the score is negative (during "the pain" and "the drain" stages) and only turns off once the animation completes at exactly 0.
     *   **`test_DisplayLogic_InGamePhase_PassesAllFarkleCounts`:** Verifies that the game logic correctly passes all players' farkle counts (not just the current player's) to the `FarkleWarningLights` component, enabling system-wide status display.
+    *   **`test_DisplayLogic_BankingPhase_NoBlinking`:** Verifies that during BankingPhase, blinkingPlayerIndex should be -1.
 
 ### 4.3 LARGE Tests (System / End-to-End Tests)
 **Focus:** The Macro Game Loop. Win conditions and game completion.
@@ -157,6 +165,7 @@ We will structure our tests into three tiers based on scope and complexity. This
 *   **`test_full_game.cpp`**
     *   **`test_FullGame_StandardGame`**: Replaces hardcoded initialization. The test now simulates the full user journey: Selecting 2-4 players -> Playing until target score -> Winner celebration -> Reset.
     *   **`test_FullGame_TripleFarkle`:** Verifies the triple farkle penalty and reset behavior.
+    *   **`test_FullGame_TripleFarkle_ScoreLessThanPenalty`:** Verifies that player score does not go negative when triple farkled.
     *   **`test_FullGame_FinalRoundBlinking`**: Verifies that the Competition Score display begins blinking as soon as the final round is triggered and remains blinking until the game ends.
 
 


### PR DESCRIPTION
Updated `design/TESTING_STRATEGY.md` to accurately reflect the tests currently in the codebase. This involved adding missing test entries for `BankingPhase`, `FarklingPhase`, `PenaltyFarklingPhase`, `WaitingPhase`, `conditional_at_risk_display`, `full_game`, `turn_lifecycle`, and `PlayerSelectionPhase`. Additionally, renamed/split tests were corrected to match the code. All native and component tests were run and passed.

---
*PR created automatically by Jules for task [14565631515313507127](https://jules.google.com/task/14565631515313507127) started by @gwenrich136*