### PR TITLE
Refactor Color Sovereignty

### DIFF
--- a/design/COMPONENT_LIBRARIES.md
+++ b/design/COMPONENT_LIBRARIES.md
@@ -70,15 +70,15 @@ The `LedProgressGrid` component manages an 8x8 NeoPixel grid to display player s
 #### Setup & State Management
 -   **`LedProgressGrid(uint8_t pin)`**: Constructor. Initializes the NeoPixel strip for a hardcoded 8x8 grid (64 pixels).
 -   **`void reset()`**: Resets the component to its initial state, clearing all player configurations and turning off all LEDs, preparing for a new game.
--   **`int addPlayer()`**: Dynamically adds a player to the grid configuration.
-    -   Assigns a unique color (hue) to the new player. The first player gets a random hue, subsequent players get hues generated using the golden ratio for maximal distinction.
+-   **`int addPlayer(uint16_t hue)`**: Dynamically adds a player to the grid configuration.
+    -   Assigns the given `hue` to the new player. The `GameState` is responsible for generating and providing this color.
     -   Returns the `playerIndex` (0-indexed) of the newly added player.
 
 #### Display Modes
 
--   **`void displayPlayersPregame(bool isPlayerPending)`**: Displays the current player setup in a pre-game or player selection screen.
+-   **`void displayPlayersPregame(std::optional<uint16_t> pendingPlayerHue)`**: Displays the current player setup in a pre-game or player selection screen.
     -   Illuminates all rows assigned to each existing player with their solid color.
-    -   If `isPlayerPending` is `true`: The rows that would be assigned to the *next* player (Player `_playerCount`) will blink with their prospective hue. If no players are added yet (`_playerCount == 0`), the middle four rows will blink.
+    -   If `pendingPlayerHue` has a value: The rows that will be assigned to the *next* player will blink with the provided prospective hue.
 
 -   **`void update(const std::vector<int>& scores, int currentPlayerIndex, int atRiskScore)`**: The primary method for rendering game scores during active gameplay. This should be called repeatedly in the main game loop.
     -   The `LedProgressGrid` internally calculates `maxScore` as the maximum of the `targetScore` and the highest potential score (banked + at-risk) among all players.

--- a/design/PRE_GAME_PHASES.md
+++ b/design/PRE_GAME_PHASES.md
@@ -54,4 +54,6 @@ The system follows this sequence:
         *   If `state.players.size() >= 1`, returns `game.getPhase<WaitingPhase>()`.
     5.  **Display Behavior (Hooks)**:
         *   **`updateTextDisplay()`**: Calls `textDisplay.printSelectionScreen("Add Player", currentSelection, getNextPlayerColor(state.players.size()))`. The `currentSelection` is rendered in the specific color that will be assigned to this player index, providing immediate visual feedback of their "identity" before they are added.
-        *   **`updateProgressGrid()`**: Calls `grid.displayPlayersPregame(isPlayerPending)`. `isPlayerPending` is true if the grid is not full.
+        *   **`updateProgressGrid()`**: Calls `grid.displayPlayersPregame(state.getNextPlayerHue(state.players.size()))`.
+            *   **Color Sovereignty:** The `GameState` acts as the single source of truth for player colors. It generates unique hues using a Golden Ratio approximation (`(index * 40503) % 65536`).
+            *   The phase queries the *prospective* hue for the next player from the `GameState` (using `std::optional` to safely manage the random seed for the first player) and passes it to the `LedProgressGrid` so the pending player's row can blink in their assigned color before confirmation.

--- a/src/farkle/include/GameState.h
+++ b/src/farkle/include/GameState.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <vector>
 #include <cstdint>
+#include <optional>
+#include <Arduino.h>
 
 #define MAX_SCORE 99999
 
@@ -11,8 +13,9 @@ struct Player {
     std::string name;
     int score;
     int farkle_count;
+    uint16_t hue;
 
-    Player(const std::string& n) : name(n), score(0), farkle_count(0) {}
+    Player(const std::string& n, uint16_t h = 0) : name(n), score(0), farkle_count(0), hue(h) {}
 };
 
 struct GameState {
@@ -24,7 +27,9 @@ struct GameState {
 
     uint32_t scoresVersion;
 
-    GameState() : atRiskScore(0), currentPlayerIndex(0), finalRoundTriggered(false), targetScore(10000), scoresVersion(1) {}
+    mutable std::optional<uint16_t> prospectiveFirstHue;
+
+    GameState() : atRiskScore(0), currentPlayerIndex(0), finalRoundTriggered(false), targetScore(10000), scoresVersion(1), prospectiveFirstHue(std::nullopt) {}
 
     void reset() {
         players.clear();
@@ -32,6 +37,18 @@ struct GameState {
         currentPlayerIndex = 0;
         finalRoundTriggered = false;
         scoresVersion++;
+        prospectiveFirstHue = std::nullopt;
+    }
+
+    uint16_t getNextPlayerHue(int playerCount) const {
+        if (!prospectiveFirstHue.has_value()) {
+            prospectiveFirstHue = random(0, 65536);
+        }
+        if (playerCount == 0) {
+            return *prospectiveFirstHue;
+        } else {
+            return (*prospectiveFirstHue + (playerCount * 40503)) % 65536;
+        }
     }
 
     void updatePlayerScore(int playerIndex, int newScore) {

--- a/src/farkle/include/GameState.h
+++ b/src/farkle/include/GameState.h
@@ -8,6 +8,8 @@
 #include <Arduino.h>
 
 #define MAX_SCORE 99999
+#define HUE_MAX_16BIT 65536
+#define HUE_GOLDEN_RATIO_JUMP 40503
 
 struct Player {
     std::string name;
@@ -42,12 +44,12 @@ struct GameState {
 
     uint16_t getNextPlayerHue(int playerCount) const {
         if (!prospectiveFirstHue.has_value()) {
-            prospectiveFirstHue = random(0, 65536);
+            prospectiveFirstHue = random(0, HUE_MAX_16BIT);
         }
         if (playerCount == 0) {
             return *prospectiveFirstHue;
         } else {
-            return (*prospectiveFirstHue + (playerCount * 40503)) % 65536;
+            return (*prospectiveFirstHue + (playerCount * HUE_GOLDEN_RATIO_JUMP)) % HUE_MAX_16BIT;
         }
     }
 

--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
@@ -8,10 +8,9 @@
 // Constructor: initializes the NeoPixel object
 LedProgressGrid::LedProgressGrid(uint8_t pin)
   : _pixels(GRID_LENGTH*GRID_LENGTH, pin, NEO_GRB + NEO_KHZ800),
-    _targetScore(10000),
-    _hasProspectiveFirstHue(false)
+    _targetScore(10000)
 {
-    memset(_playerHues, 0, sizeof(_playerHues));
+    memset(_playerColors, 0, sizeof(_playerColors));
     _lastState.isDirty = true;
 }
 
@@ -26,21 +25,39 @@ void LedProgressGrid::setTargetScore(int target) {
     _lastState.isDirty = true;
 }
 
-void LedProgressGrid::illuminate_row(int row, uint16_t hue, float ratio, uint8_t brightness) {
+uint32_t LedProgressGrid::scaleColorBrightness(uint32_t color, uint8_t brightness) {
+    if (brightness == 255) return color;
+    if (brightness == 0) return 0;
+
+    // Extract RGB from 32-bit color (0x00RRGGBB)
+    uint8_t r = (color >> 16) & 0xFF;
+    uint8_t g = (color >>  8) & 0xFF;
+    uint8_t b =  color        & 0xFF;
+
+    // Scale and shift
+    r = (r * brightness) >> 8;
+    g = (g * brightness) >> 8;
+    b = (b * brightness) >> 8;
+
+    return _pixels.Color(r, g, b);
+}
+
+void LedProgressGrid::illuminate_row(int row, uint32_t baseColor, float ratio, uint8_t brightness) {
   int num_pixels = (int) (ratio * GRID_LENGTH);
   float remainder = (ratio * GRID_LENGTH) - num_pixels;
   // rows snake, so we need to count backwards for odd rows
-    uint32_t color = _pixels.ColorHSV(hue, 255, brightness);
+    uint32_t solidColor = scaleColorBrightness(baseColor, brightness);
     for (int col = 0; col < num_pixels; ++col) {
       _pixels.setPixelColor(
         get_pixel_index(row, col),
-        color);
+        solidColor);
     }
     // Only draw partial pixel if we haven't filled the row
     if (num_pixels < GRID_LENGTH) {
+      uint32_t partialColor = scaleColorBrightness(baseColor, getRemainderBrightness(remainder, brightness));
       _pixels.setPixelColor(
         get_pixel_index(row, num_pixels),
-        _pixels.ColorHSV(hue, 255, getRemainderBrightness(remainder, brightness))
+        partialColor
       );
     }
 }
@@ -75,18 +92,15 @@ int LedProgressGrid::getRemainderBrightness(float remainder, int fullBrightness)
   return (int) (fullBrightness * y);
 }
 
-int LedProgressGrid::addPlayer() {
-    if (isMaxPlayersReached()) {
+int LedProgressGrid::addPlayer(int playerIndex, uint16_t hue) {
+    if (isMaxPlayersReached() || playerIndex != _playerCount) {
         return -1;
     }
 
-    uint16_t newHue = getPlayerHue(_playerCount);
-    _playerHues[_playerCount] = newHue;
+    _playerColors[playerIndex] = _pixels.ColorHSV(hue, 255, 255);
     
-    int playerIndex = _playerCount;
     _playerCount++;
     _lastState.isDirty = true;
-    _hasProspectiveFirstHue = false;
     
     return playerIndex;
 }
@@ -104,7 +118,6 @@ void LedProgressGrid::clear() {
 
 void LedProgressGrid::reset() {
   _playerCount = 0;
-  _hasProspectiveFirstHue = false;
 
   _maxScore = _targetScore;
   _isBlinkOn = false;
@@ -121,26 +134,9 @@ bool LedProgressGrid::shouldRefresh(const State& newState) {
     return false;
 }
 
-uint16_t LedProgressGrid::getPlayerHue(int playerIdx) {
-    if (playerIdx < _playerCount) {
-        return _playerHues[playerIdx];
-    }
-
-    // Pending player logic
-    if (_playerCount == 0) {
-        if (!_hasProspectiveFirstHue) {
-            _prospectiveFirstHue = random(0, 65536);
-            _hasProspectiveFirstHue = true;
-        }
-        return _prospectiveFirstHue;
-    } else {
-        return (uint16_t)(_playerHues[_playerCount - 1] + (GOLDEN_RATIO_CONJUGATE * 65536)) % 65536;
-    }
-}
-
-void LedProgressGrid::renderPlayerRows(PlayerRows rows, uint16_t hue, float ratio, uint8_t brightness) {
+void LedProgressGrid::renderPlayerRows(PlayerRows rows, uint32_t baseColor, float ratio, uint8_t brightness) {
     for (int r = 0; r < rows.numRows; ++r) {
-        illuminate_row(rows.startRow + r, hue, ratio, brightness);
+        illuminate_row(rows.startRow + r, baseColor, ratio, brightness);
     }
 }
 
@@ -202,13 +198,14 @@ void LedProgressGrid::update(const int* scores, int playerCount, int currentPlay
     float ratioToDraw = (float)scoreToDraw / _maxScore;
     if (ratioToDraw > 1.0f) ratioToDraw = 1.0f;
 
-    renderPlayerRows(rows, _playerHues[playerIdx], ratioToDraw, 128);
+    renderPlayerRows(rows, _playerColors[playerIdx], ratioToDraw, 128);
   }
 
   _pixels.show();
 }
 
-void LedProgressGrid::displayPlayersPregame(bool isPlayerPending) {
+void LedProgressGrid::displayPlayersPregame(std::optional<uint16_t> pendingPlayerHue) {
+  bool isPlayerPending = pendingPlayerHue.has_value();
   if (isMaxPlayersReached()) {
     isPlayerPending = false;
   }
@@ -234,15 +231,15 @@ void LedProgressGrid::displayPlayersPregame(bool isPlayerPending) {
   // Draw existing players
   for (int playerIdx = 0; playerIdx < _playerCount; ++playerIdx) {
       PlayerRows rows = PlayerLayout::getMapping(effectivePlayerCount, playerIdx);
-      renderPlayerRows(rows, _playerHues[playerIdx], 1.0f, 128);
+      renderPlayerRows(rows, _playerColors[playerIdx], 1.0f, 128);
   }
 
   // Draw pending player
   if (isPlayerPending && _isBlinkOn) {
       int pendingIdx = _playerCount;
       PlayerRows rows = PlayerLayout::getMapping(effectivePlayerCount, pendingIdx);
-      uint16_t hue = getPlayerHue(pendingIdx);
-      renderPlayerRows(rows, hue, 1.0f, 128);
+      uint32_t pendingColor = _pixels.ColorHSV(*pendingPlayerHue, 255, 255);
+      renderPlayerRows(rows, pendingColor, 1.0f, 128);
   }
 
   _pixels.show();

--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.cpp
@@ -10,7 +10,7 @@ LedProgressGrid::LedProgressGrid(uint8_t pin)
   : _pixels(GRID_LENGTH*GRID_LENGTH, pin, NEO_GRB + NEO_KHZ800),
     _targetScore(10000)
 {
-    memset(_playerColors, 0, sizeof(_playerColors));
+    memset(_playerHues, 0, sizeof(_playerHues));
     _lastState.isDirty = true;
 }
 
@@ -25,39 +25,21 @@ void LedProgressGrid::setTargetScore(int target) {
     _lastState.isDirty = true;
 }
 
-uint32_t LedProgressGrid::scaleColorBrightness(uint32_t color, uint8_t brightness) {
-    if (brightness == 255) return color;
-    if (brightness == 0) return 0;
-
-    // Extract RGB from 32-bit color (0x00RRGGBB)
-    uint8_t r = (color >> 16) & 0xFF;
-    uint8_t g = (color >>  8) & 0xFF;
-    uint8_t b =  color        & 0xFF;
-
-    // Scale and shift
-    r = (r * brightness) >> 8;
-    g = (g * brightness) >> 8;
-    b = (b * brightness) >> 8;
-
-    return _pixels.Color(r, g, b);
-}
-
-void LedProgressGrid::illuminate_row(int row, uint32_t baseColor, float ratio, uint8_t brightness) {
+void LedProgressGrid::illuminate_row(int row, uint16_t hue, float ratio, uint8_t brightness) {
   int num_pixels = (int) (ratio * GRID_LENGTH);
   float remainder = (ratio * GRID_LENGTH) - num_pixels;
   // rows snake, so we need to count backwards for odd rows
-    uint32_t solidColor = scaleColorBrightness(baseColor, brightness);
+    uint32_t color = _pixels.ColorHSV(hue, 255, brightness);
     for (int col = 0; col < num_pixels; ++col) {
       _pixels.setPixelColor(
         get_pixel_index(row, col),
-        solidColor);
+        color);
     }
     // Only draw partial pixel if we haven't filled the row
     if (num_pixels < GRID_LENGTH) {
-      uint32_t partialColor = scaleColorBrightness(baseColor, getRemainderBrightness(remainder, brightness));
       _pixels.setPixelColor(
         get_pixel_index(row, num_pixels),
-        partialColor
+        _pixels.ColorHSV(hue, 255, getRemainderBrightness(remainder, brightness))
       );
     }
 }
@@ -92,13 +74,14 @@ int LedProgressGrid::getRemainderBrightness(float remainder, int fullBrightness)
   return (int) (fullBrightness * y);
 }
 
-int LedProgressGrid::addPlayer(int playerIndex, uint16_t hue) {
-    if (isMaxPlayersReached() || playerIndex != _playerCount) {
+int LedProgressGrid::addPlayer(uint16_t hue) {
+    if (isMaxPlayersReached()) {
         return -1;
     }
 
-    _playerColors[playerIndex] = _pixels.ColorHSV(hue, 255, 255);
+    _playerHues[_playerCount] = hue;
     
+    int playerIndex = _playerCount;
     _playerCount++;
     _lastState.isDirty = true;
     
@@ -134,9 +117,9 @@ bool LedProgressGrid::shouldRefresh(const State& newState) {
     return false;
 }
 
-void LedProgressGrid::renderPlayerRows(PlayerRows rows, uint32_t baseColor, float ratio, uint8_t brightness) {
+void LedProgressGrid::renderPlayerRows(PlayerRows rows, uint16_t hue, float ratio, uint8_t brightness) {
     for (int r = 0; r < rows.numRows; ++r) {
-        illuminate_row(rows.startRow + r, baseColor, ratio, brightness);
+        illuminate_row(rows.startRow + r, hue, ratio, brightness);
     }
 }
 
@@ -198,7 +181,7 @@ void LedProgressGrid::update(const int* scores, int playerCount, int currentPlay
     float ratioToDraw = (float)scoreToDraw / _maxScore;
     if (ratioToDraw > 1.0f) ratioToDraw = 1.0f;
 
-    renderPlayerRows(rows, _playerColors[playerIdx], ratioToDraw, 128);
+    renderPlayerRows(rows, _playerHues[playerIdx], ratioToDraw, 128);
   }
 
   _pixels.show();
@@ -231,15 +214,14 @@ void LedProgressGrid::displayPlayersPregame(std::optional<uint16_t> pendingPlaye
   // Draw existing players
   for (int playerIdx = 0; playerIdx < _playerCount; ++playerIdx) {
       PlayerRows rows = PlayerLayout::getMapping(effectivePlayerCount, playerIdx);
-      renderPlayerRows(rows, _playerColors[playerIdx], 1.0f, 128);
+      renderPlayerRows(rows, _playerHues[playerIdx], 1.0f, 128);
   }
 
   // Draw pending player
   if (isPlayerPending && _isBlinkOn) {
       int pendingIdx = _playerCount;
       PlayerRows rows = PlayerLayout::getMapping(effectivePlayerCount, pendingIdx);
-      uint32_t pendingColor = _pixels.ColorHSV(*pendingPlayerHue, 255, 255);
-      renderPlayerRows(rows, pendingColor, 1.0f, 128);
+      renderPlayerRows(rows, *pendingPlayerHue, 1.0f, 128);
   }
 
   _pixels.show();

--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.h
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.h
@@ -3,6 +3,7 @@
 
 #include <Arduino.h>
 #include <Adafruit_NeoPixel.h>
+#include <optional>
 #include "PlayerLayout.h"
 #include "GameConstants.h"
 
@@ -49,34 +50,32 @@ public:
   LedProgressGrid(uint8_t pin);
   void begin();
   void setTargetScore(int target);
-  int addPlayer();
+  int addPlayer(int playerIndex, uint16_t hue);
   bool isMaxPlayersReached();
   void reset();
   void clear();
   void update(const int* scores, int playerCount, int currentPlayerIndex, int blinkingScore);
-  void displayPlayersPregame(bool isPlayerPending);
+  void displayPlayersPregame(std::optional<uint16_t> pendingPlayerHue);
   int getMaxScore() const { return _maxScore; }
 
 private:
   Adafruit_NeoPixel _pixels;
 
   int _playerCount;
-  uint16_t _playerHues[MAX_PLAYERS];
+  uint32_t _playerColors[MAX_PLAYERS];
   int _maxScore;
   int _targetScore;
   bool _isBlinkOn;
 
   State _lastState;
-  uint16_t _prospectiveFirstHue;
-  bool _hasProspectiveFirstHue;
 
-  void illuminate_row(int row, uint16_t hue, float ratio, uint8_t brightness = 255);
+  void illuminate_row(int row, uint32_t baseColor, float ratio, uint8_t brightness = 255);
   int get_pixel_index(int row, int col);
   int getRemainderBrightness(float remainder, int fullBrightness);
+  uint32_t scaleColorBrightness(uint32_t color, uint8_t brightness);
 
   bool shouldRefresh(const State& newState);
-  void renderPlayerRows(PlayerRows rows, uint16_t hue, float ratio, uint8_t brightness);
-  uint16_t getPlayerHue(int playerIdx);
+  void renderPlayerRows(PlayerRows rows, uint32_t baseColor, float ratio, uint8_t brightness);
 };
 
 #endif

--- a/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.h
+++ b/src/farkle/lib/components/LedProgressGrid/LedProgressGrid.h
@@ -50,7 +50,7 @@ public:
   LedProgressGrid(uint8_t pin);
   void begin();
   void setTargetScore(int target);
-  int addPlayer(int playerIndex, uint16_t hue);
+  int addPlayer(uint16_t hue);
   bool isMaxPlayersReached();
   void reset();
   void clear();
@@ -62,20 +62,19 @@ private:
   Adafruit_NeoPixel _pixels;
 
   int _playerCount;
-  uint32_t _playerColors[MAX_PLAYERS];
+  uint16_t _playerHues[MAX_PLAYERS];
   int _maxScore;
   int _targetScore;
   bool _isBlinkOn;
 
   State _lastState;
 
-  void illuminate_row(int row, uint32_t baseColor, float ratio, uint8_t brightness = 255);
+  void illuminate_row(int row, uint16_t hue, float ratio, uint8_t brightness = 255);
   int get_pixel_index(int row, int col);
   int getRemainderBrightness(float remainder, int fullBrightness);
-  uint32_t scaleColorBrightness(uint32_t color, uint8_t brightness);
 
   bool shouldRefresh(const State& newState);
-  void renderPlayerRows(PlayerRows rows, uint32_t baseColor, float ratio, uint8_t brightness);
+  void renderPlayerRows(PlayerRows rows, uint16_t hue, float ratio, uint8_t brightness);
 };
 
 #endif

--- a/src/farkle/src/Game.cpp
+++ b/src/farkle/src/Game.cpp
@@ -71,8 +71,9 @@ void Game::loop() {
 
 void Game::addPlayer(const std::string& name) {
     if (!canAddPlayer()) return;
-    state.players.push_back(Player(name));
-    grid.addPlayer();
+    uint16_t hue = state.getNextPlayerHue(state.players.size());
+    state.players.push_back(Player(name, hue));
+    grid.addPlayer(state.players.size() - 1, hue);
 }
 
 bool Game::canAddPlayer() {

--- a/src/farkle/src/Game.cpp
+++ b/src/farkle/src/Game.cpp
@@ -73,7 +73,7 @@ void Game::addPlayer(const std::string& name) {
     if (!canAddPlayer()) return;
     uint16_t hue = state.getNextPlayerHue(state.players.size());
     state.players.push_back(Player(name, hue));
-    grid.addPlayer(state.players.size() - 1, hue);
+    grid.addPlayer(hue);
 }
 
 bool Game::canAddPlayer() {

--- a/src/farkle/src/phases/PlayerSelectionPhase.cpp
+++ b/src/farkle/src/phases/PlayerSelectionPhase.cpp
@@ -55,7 +55,11 @@ GamePhase* PlayerSelectionPhase::update(Game& game, GameState& state, GameInput 
 
 void PlayerSelectionPhase::updateProgressGrid(const GameState& state, const Displays& displays) {
     bool isRosterFull = state.players.size() >= MAX_PLAYERS;
-    displays.grid.displayPlayersPregame(!isRosterFull);
+    if (!isRosterFull) {
+        displays.grid.displayPlayersPregame(state.getNextPlayerHue(state.players.size()));
+    } else {
+        displays.grid.displayPlayersPregame(std::nullopt);
+    }
 }
 
 void PlayerSelectionPhase::updateTextDisplay(const GameState& state, const Displays& displays) {

--- a/src/farkle/test/mocks/include/LedProgressGrid.h
+++ b/src/farkle/test/mocks/include/LedProgressGrid.h
@@ -21,7 +21,7 @@ public:
     LedProgressGrid(uint8_t pin);
     void begin();
     void setTargetScore(int target);
-    int addPlayer(int playerIndex, uint16_t hue);
+    int addPlayer(uint16_t hue);
     bool isMaxPlayersReached();
     void reset();
     void clear();

--- a/src/farkle/test/mocks/include/LedProgressGrid.h
+++ b/src/farkle/test/mocks/include/LedProgressGrid.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <cstdint>
+#include <optional>
 #include "GameConstants.h"
 
 class LedProgressGrid {
@@ -20,12 +21,12 @@ public:
     LedProgressGrid(uint8_t pin);
     void begin();
     void setTargetScore(int target);
-    int addPlayer();
+    int addPlayer(int playerIndex, uint16_t hue);
     bool isMaxPlayersReached();
     void reset();
     void clear();
     void update(const int* scores, int playerCount, int currentPlayerIndex, int blinkingScore);
-    void displayPlayersPregame(bool isPlayerPending);
+    void displayPlayersPregame(std::optional<uint16_t> pendingPlayerHue);
 };
 
 #endif // MOCK_LED_PROGRESS_GRID_H

--- a/src/farkle/test/mocks/src/LedProgressGrid.cpp
+++ b/src/farkle/test/mocks/src/LedProgressGrid.cpp
@@ -12,8 +12,8 @@ void LedProgressGrid::setTargetScore(int target) {
     captured_targetScore = target;
 }
 
-int LedProgressGrid::addPlayer() {
-    if (isMaxPlayersReached()) {
+int LedProgressGrid::addPlayer(int playerIndex, uint16_t hue) {
+    if (isMaxPlayersReached() || playerIndex != player_count) {
         return -1;
     }
     return player_count++;
@@ -41,6 +41,6 @@ void LedProgressGrid::update(const int* scores, int playerCount, int currentPlay
     captured_blinkingScore = blinkingScore;
 }
 
-void LedProgressGrid::displayPlayersPregame(bool isPlayerPending) {
+void LedProgressGrid::displayPlayersPregame(std::optional<uint16_t> pendingPlayerHue) {
     // Mock implementation for pregame
 }

--- a/src/farkle/test/mocks/src/LedProgressGrid.cpp
+++ b/src/farkle/test/mocks/src/LedProgressGrid.cpp
@@ -12,8 +12,8 @@ void LedProgressGrid::setTargetScore(int target) {
     captured_targetScore = target;
 }
 
-int LedProgressGrid::addPlayer(int playerIndex, uint16_t hue) {
-    if (isMaxPlayersReached() || playerIndex != player_count) {
+int LedProgressGrid::addPlayer(uint16_t hue) {
+    if (isMaxPlayersReached()) {
         return -1;
     }
     return player_count++;

--- a/src/farkle/test/test_component_led_progress_grid/test_led_progress_grid.cpp
+++ b/src/farkle/test/test_component_led_progress_grid/test_led_progress_grid.cpp
@@ -31,8 +31,8 @@ void test_LedProgressGrid_InitialState(void) {
 }
 
 void test_LedProgressGrid_AddPlayer(void) {
-    int p1 = grid->addPlayer(0, 0);
-    int p2 = grid->addPlayer(1, 0);
+    int p1 = grid->addPlayer(0);
+    int p2 = grid->addPlayer(0);
 
     TEST_ASSERT_EQUAL(0, p1);
     TEST_ASSERT_EQUAL(1, p2);
@@ -42,8 +42,8 @@ void test_LedProgressGrid_Optimization(void) {
     // This test verifies that multiple calls to update() with same state
     // do NOT trigger multiple calls to show().
     std::vector<int> scores = {1000, 2000};
-    grid->addPlayer(0, 0); // p0
-    grid->addPlayer(1, 0); // p1
+    grid->addPlayer(0); // p0
+    grid->addPlayer(0); // p1
 
     mockNeoPixelShowCount = 0;
     grid->update(scores.data(), scores.size(), 0, 0);
@@ -92,7 +92,7 @@ void test_LedProgressGrid_Pregame_Blink_Optimization(void) {
 }
 
 void test_LedProgressGrid_Update_Basic(void) {
-    grid->addPlayer(0, 0);
+    grid->addPlayer(0);
     std::vector<int> scores = {5000};
     grid->update(scores.data(), scores.size(), 0, 0);
 
@@ -113,7 +113,7 @@ void test_LedProgressGrid_Update_Basic(void) {
 
 void test_LedProgressGrid_InsufficientScores(void) {
     // If we have more players than scores provided, update should return early (safety check)
-    grid->addPlayer(0, 0); // 1 player
+    grid->addPlayer(0); // 1 player
     std::vector<int> emptyScores; // 0 scores
 
     mockNeoPixelShowCount = 0;
@@ -126,7 +126,7 @@ void test_LedProgressGrid_InsufficientScores(void) {
 void test_LedProgressGrid_MaxPlayers(void) {
     // Add 8 players (MAX_PLAYERS)
     for (int i = 0; i < 8; ++i) {
-        int idx = grid->addPlayer(i, 0);
+        int idx = grid->addPlayer(0);
         TEST_ASSERT_EQUAL(i, idx);
 
         // Before the last one, it shouldn't be full yet?
@@ -141,14 +141,14 @@ void test_LedProgressGrid_MaxPlayers(void) {
     TEST_ASSERT_TRUE(grid->isMaxPlayersReached());
 
     // Try adding 9th player
-    int idx = grid->addPlayer(8, 0);
+    int idx = grid->addPlayer(0);
     TEST_ASSERT_EQUAL(-1, idx);
     TEST_ASSERT_TRUE(grid->isMaxPlayersReached());
 }
 
 void test_LedProgressGrid_SetTargetScore(void) {
     mockNeoPixelShowCount = 0;
-    grid->addPlayer(0, 0);
+    grid->addPlayer(0);
     std::vector<int> scores = {1000};
 
     // Default target is 10000. 1000/10000 = 0.1 ratio -> 0.8 pixels (1 pixel total brightness)
@@ -169,7 +169,7 @@ void test_LedProgressGrid_SetTargetScore(void) {
 void test_LedProgressGrid_MaxScore_Exact(void) {
     // Verify that _maxScore is exactly highestScore (if > _targetScore) and not a multiple of 2000.
     grid->setTargetScore(10000);
-    grid->addPlayer(0, 0);
+    grid->addPlayer(0);
     std::vector<int> scores = {11000};
 
     grid->update(scores.data(), scores.size(), 0, 0);
@@ -180,7 +180,7 @@ void test_LedProgressGrid_MaxScore_Exact(void) {
 void test_LedProgressGrid_MaxScore_IncludesAtRisk(void) {
     // Verify that _maxScore takes blinkingScore into account.
     grid->setTargetScore(10000);
-    grid->addPlayer(0, 0);
+    grid->addPlayer(0);
     std::vector<int> scores = {9000};
 
     grid->update(scores.data(), scores.size(), 0, 1500); // 9000 + 1500 = 10500
@@ -190,7 +190,7 @@ void test_LedProgressGrid_MaxScore_IncludesAtRisk(void) {
 void test_LedProgressGrid_MaxScore_Shrinking(void) {
     // Verify that _maxScore shrinks when the leading player's score decreases.
     grid->setTargetScore(10000);
-    grid->addPlayer(0, 0);
+    grid->addPlayer(0);
     std::vector<int> scores = {12000};
 
     grid->update(scores.data(), scores.size(), 0, 0);

--- a/src/farkle/test/test_component_led_progress_grid/test_led_progress_grid.cpp
+++ b/src/farkle/test/test_component_led_progress_grid/test_led_progress_grid.cpp
@@ -31,8 +31,8 @@ void test_LedProgressGrid_InitialState(void) {
 }
 
 void test_LedProgressGrid_AddPlayer(void) {
-    int p1 = grid->addPlayer();
-    int p2 = grid->addPlayer();
+    int p1 = grid->addPlayer(0, 0);
+    int p2 = grid->addPlayer(1, 0);
 
     TEST_ASSERT_EQUAL(0, p1);
     TEST_ASSERT_EQUAL(1, p2);
@@ -42,8 +42,8 @@ void test_LedProgressGrid_Optimization(void) {
     // This test verifies that multiple calls to update() with same state
     // do NOT trigger multiple calls to show().
     std::vector<int> scores = {1000, 2000};
-    grid->addPlayer(); // p0
-    grid->addPlayer(); // p1
+    grid->addPlayer(0, 0); // p0
+    grid->addPlayer(1, 0); // p1
 
     mockNeoPixelShowCount = 0;
     grid->update(scores.data(), scores.size(), 0, 0);
@@ -72,27 +72,27 @@ void test_LedProgressGrid_Pregame_Blink_Optimization(void) {
 
     // Force 100ms
     advance_millis(100);
-    grid->displayPlayersPregame(true);
+    grid->displayPlayersPregame(0);
     int count1 = mockNeoPixelShowCount;
     TEST_ASSERT_EQUAL(1, count1);
 
     // Call again at same time
-    grid->displayPlayersPregame(true);
+    grid->displayPlayersPregame(0);
     TEST_ASSERT_EQUAL(count1, mockNeoPixelShowCount);
 
     // Advance 50ms (still < 500ms, so blink state same)
     advance_millis(50);
-    grid->displayPlayersPregame(true);
+    grid->displayPlayersPregame(0);
     TEST_ASSERT_EQUAL(count1, mockNeoPixelShowCount);
 
     // Advance to 600ms (blink state changes)
     advance_millis(450); // 100 + 50 + 450 = 600
-    grid->displayPlayersPregame(true);
+    grid->displayPlayersPregame(0);
     TEST_ASSERT_EQUAL(count1 + 1, mockNeoPixelShowCount);
 }
 
 void test_LedProgressGrid_Update_Basic(void) {
-    grid->addPlayer();
+    grid->addPlayer(0, 0);
     std::vector<int> scores = {5000};
     grid->update(scores.data(), scores.size(), 0, 0);
 
@@ -113,7 +113,7 @@ void test_LedProgressGrid_Update_Basic(void) {
 
 void test_LedProgressGrid_InsufficientScores(void) {
     // If we have more players than scores provided, update should return early (safety check)
-    grid->addPlayer(); // 1 player
+    grid->addPlayer(0, 0); // 1 player
     std::vector<int> emptyScores; // 0 scores
 
     mockNeoPixelShowCount = 0;
@@ -126,7 +126,7 @@ void test_LedProgressGrid_InsufficientScores(void) {
 void test_LedProgressGrid_MaxPlayers(void) {
     // Add 8 players (MAX_PLAYERS)
     for (int i = 0; i < 8; ++i) {
-        int idx = grid->addPlayer();
+        int idx = grid->addPlayer(i, 0);
         TEST_ASSERT_EQUAL(i, idx);
 
         // Before the last one, it shouldn't be full yet?
@@ -141,14 +141,14 @@ void test_LedProgressGrid_MaxPlayers(void) {
     TEST_ASSERT_TRUE(grid->isMaxPlayersReached());
 
     // Try adding 9th player
-    int idx = grid->addPlayer();
+    int idx = grid->addPlayer(8, 0);
     TEST_ASSERT_EQUAL(-1, idx);
     TEST_ASSERT_TRUE(grid->isMaxPlayersReached());
 }
 
 void test_LedProgressGrid_SetTargetScore(void) {
     mockNeoPixelShowCount = 0;
-    grid->addPlayer();
+    grid->addPlayer(0, 0);
     std::vector<int> scores = {1000};
 
     // Default target is 10000. 1000/10000 = 0.1 ratio -> 0.8 pixels (1 pixel total brightness)
@@ -169,7 +169,7 @@ void test_LedProgressGrid_SetTargetScore(void) {
 void test_LedProgressGrid_MaxScore_Exact(void) {
     // Verify that _maxScore is exactly highestScore (if > _targetScore) and not a multiple of 2000.
     grid->setTargetScore(10000);
-    grid->addPlayer();
+    grid->addPlayer(0, 0);
     std::vector<int> scores = {11000};
 
     grid->update(scores.data(), scores.size(), 0, 0);
@@ -180,7 +180,7 @@ void test_LedProgressGrid_MaxScore_Exact(void) {
 void test_LedProgressGrid_MaxScore_IncludesAtRisk(void) {
     // Verify that _maxScore takes blinkingScore into account.
     grid->setTargetScore(10000);
-    grid->addPlayer();
+    grid->addPlayer(0, 0);
     std::vector<int> scores = {9000};
 
     grid->update(scores.data(), scores.size(), 0, 1500); // 9000 + 1500 = 10500
@@ -190,7 +190,7 @@ void test_LedProgressGrid_MaxScore_IncludesAtRisk(void) {
 void test_LedProgressGrid_MaxScore_Shrinking(void) {
     // Verify that _maxScore shrinks when the leading player's score decreases.
     grid->setTargetScore(10000);
-    grid->addPlayer();
+    grid->addPlayer(0, 0);
     std::vector<int> scores = {12000};
 
     grid->update(scores.data(), scores.size(), 0, 0);


### PR DESCRIPTION
Implements "Task 1: Color Sovereignty Refactor" to decouple visual identity (hues/colors) from hardware-specific components (`LedProgressGrid`). The `GameState` now fully owns and generates the hue mapping per player.

---
*PR created automatically by Jules for task [11652580461742399528](https://jules.google.com/task/11652580461742399528) started by @gwenrich136*