### PR TITLE
Enhance Text Display Font Size and Player Color Integration

### DIFF
--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
@@ -1,5 +1,5 @@
 #include "TextDisplayV2.h"
-#include <Fonts/FreeSans9pt7b.h>
+#include <Fonts/FreeSans18pt7b.h>
 #include <math.h>
 #include <cstring>
 
@@ -31,18 +31,21 @@ void TextDisplayV2::begin() {
   Serial.println("    TEXTV2: Init complete.");
 }
 
-void TextDisplayV2::print(const char* message)
+void TextDisplayV2::print(const char* message, uint16_t hue)
 {
-  if (_currentMode == DisplayModeV2::MESSAGE && strcmp(_lastMessage, message) == 0) {
+  if (_currentMode == DisplayModeV2::MESSAGE && strcmp(_lastMessage, message) == 0 && _lastHue == hue) {
     return; // State cache
   }
   _currentMode = DisplayModeV2::MESSAGE;
   strncpy(_lastMessage, message, sizeof(_lastMessage) - 1);
   _lastMessage[sizeof(_lastMessage) - 1] = '\0';
+  _lastHue = hue;
 
   _display.fillScreen(ST77XX_BLACK);
-  _display.setFont(&FreeSans9pt7b);
-  _display.setTextColor(ST77XX_WHITE);
+  _display.setFont(&FreeSans18pt7b);
+
+  uint16_t textColor = (hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(hue);
+  _display.setTextColor(textColor);
 
   int16_t x1, y1;
   uint16_t w, h;
@@ -71,7 +74,7 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
     _lastHue = hue;
 
     _display.fillScreen(ST77XX_BLACK);
-    _display.setFont(&FreeSans9pt7b);
+    _display.setFont(&FreeSans18pt7b);
 
     // Resolve color
     uint16_t itemColor = (hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(hue);

--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.h
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.h
@@ -26,7 +26,7 @@ class TextDisplayV2
   public:
     TextDisplayV2(int cs, int dc, int res, int blk);
     void begin();
-    void print(const char* message);
+    void print(const char* message, uint16_t hue = 0xFFFF);
     void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue = 0xFFFF);
 
     // Color conversion utility

--- a/src/farkle/src/phases/InGamePhase.cpp
+++ b/src/farkle/src/phases/InGamePhase.cpp
@@ -73,7 +73,7 @@ void InGamePhase::updateWarningLights(const GameState& state, const Displays& di
 
 void InGamePhase::updateTextDisplay(const GameState& state, const Displays& displays) {
     // Basic turn indicator for now
-    displays.textDisplay.print(state.players[state.currentPlayerIndex].name.c_str());
+    displays.textDisplay.print(state.players[state.currentPlayerIndex].name.c_str(), state.players[state.currentPlayerIndex].hue);
 }
 
 int InGamePhase::calculateLeadingScore(const GameState& state) {

--- a/src/farkle/test/mocks/include/TextDisplayV2.h
+++ b/src/farkle/test/mocks/include/TextDisplayV2.h
@@ -13,7 +13,7 @@ public:
 
     TextDisplayV2(int cs, int dc, int res, int blk);
     void begin();
-    void print(const char* message);
+    void print(const char* message, uint16_t hue = 0xFFFF);
     void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue = 0xFFFF);
 };
 

--- a/src/farkle/test/mocks/libs/Adafruit_GFX.h
+++ b/src/farkle/test/mocks/libs/Adafruit_GFX.h
@@ -24,6 +24,7 @@ typedef struct {
 } GFXfont;
 
 extern const GFXfont FreeSans9pt7b;
+extern const GFXfont FreeSans18pt7b;
 
 struct MockAdafruitPrintCall {
     std::string str;

--- a/src/farkle/test/mocks/libs/Fonts/FreeSans18pt7b.h
+++ b/src/farkle/test/mocks/libs/Fonts/FreeSans18pt7b.h
@@ -1,0 +1,7 @@
+#ifndef _FREESANS18PT7B_H
+#define _FREESANS18PT7B_H
+
+#include "../Adafruit_GFX.h"
+
+// Font included from Adafruit_GFX.cpp mock
+#endif

--- a/src/farkle/test/mocks/src/Adafruit_GFX.cpp
+++ b/src/farkle/test/mocks/src/Adafruit_GFX.cpp
@@ -9,3 +9,4 @@ int mockAdafruitFillScreenCount = 0;
 
 // Dummy Font definition
 const GFXfont FreeSans9pt7b = {nullptr, nullptr, 0x20, 0x7E, 22};
+const GFXfont FreeSans18pt7b = {nullptr, nullptr, 0x20, 0x7E, 44};

--- a/src/farkle/test/mocks/src/TextDisplayV2.cpp
+++ b/src/farkle/test/mocks/src/TextDisplayV2.cpp
@@ -8,8 +8,9 @@ void TextDisplayV2::begin() {
     // Begin can be empty for the mock
 }
 
-void TextDisplayV2::print(const char* message) {
+void TextDisplayV2::print(const char* message, uint16_t hue) {
     captured_message = message;
+    captured_hue = hue;
 }
 
 void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue) {


### PR DESCRIPTION
Increased the font size across TextDisplayV2 to improve legibility on the LCD, scaling it up to FreeSans18pt7b. Added the capability for the `print` function to use color natively, and implemented it within `InGamePhase` so that the player's name is dynamically rendered in their assigned hue matching their color in the game state. Mock interfaces and tests have also been updated to pass successfully.

---
*PR created automatically by Jules for task [1615885720651004236](https://jules.google.com/task/1615885720651004236) started by @gwenrich136*