### PR TITLE
Update Design Docs for Migration Step 3

### DIFF
--- a/design/COMPONENT_LIBRARIES.md
+++ b/design/COMPONENT_LIBRARIES.md
@@ -113,7 +113,7 @@ The `LedProgressGrid` component manages an 8x8 NeoPixel grid to display player s
 The `ScoreDisplay` component controls three 5-digit 7-segment displays (driven by MAX7219 chips) to show various numerical scores from the game.
 
 ### API Design
--   **`ScoreDisplay(int dataPin, int clkPin, int csPin)`**: Constructor. Initializes the `LedControl` library. In the Hardware SPI configuration (Step 3+), `dataPin` and `clkPin` must match the hardware SPI MOSI (D11) and SCK (D13) pins respectively.
+-   **`ScoreDisplay(int csPin)`**: Constructor. Initializes the hardware SPI directly. It uses the default SPI MOSI (D11) and SCK (D13) pins.
 -   **`void addDisplay(DisplayType type, int deviceIndex)`**: Maps a logical `DisplayType` to a physical `deviceIndex`.
 -   **`void print_number(int number, DisplayType type, bool blink = false)`**: Displays an integer `number` on the display mapped to the given `DisplayType`.
     -   The number will be right-aligned on the 5-digit display.
@@ -129,7 +129,7 @@ The `ScoreDisplay` component controls three 5-digit 7-segment displays (driven b
 -   **Score Overflow Handling:** If the input `number` exceeds 99,999, the display will show `99999`.
 -   **Blinking Capability:** When enabled via `print_number`, the component uses `millis()` to toggle the device's intensity between two levels (4 and 10 on a 0-15 scale) every 500ms. This is non-blocking and relies on `print_number` being called frequently in the main game loop to update the intensity state.
 -   **Memory-Efficient Implementation:** The digit extraction and formatting are implemented using stack-allocated character buffers and integer arithmetic to avoid dynamic memory allocation and `std::string` overhead on the embedded target.
-- **Memory & Optimization:** To prevent unnecessary hardware communication, the component maintains a `State` "memory" for each of the three displays. It only calls `LedControl` methods (`setIntensity`, `clearDisplay`, `setChar`) if the requested state (number, blink mode, or calculated intensity) has changed since the last update.
+- **Memory & Optimization:** To prevent unnecessary hardware communication, the component maintains a `State` "memory" for each of the three displays. It only writes to MAX7219 registers if the requested state (number, blink mode, or calculated intensity) has changed since the last update.
 
 ---
 
@@ -180,17 +180,17 @@ The `TextDisplayV2` component is a high-performance UI manager for the **ST7789 
 ### API Design
 
 #### Static Text Display Modes
--   **`void print(const char* message)`**: Displays a single message centered on the 240x240 screen.
+-   **`void print(const char* message, uint16_t hue = 0xFFFF)`**: Displays a single message centered on the 240x240 screen, optionally rendering the text in a specific `hue`.
 -   **`void displayTitle(const char* title)`**: Displays a single line of `title` text, centered horizontally and vertically.
 -   **`void displayTitleWithSubtitle(const char* title, const char* subtitle)`**: Displays a main `title` centered towards the top, with a smaller `subtitle` centered towards the bottom.
 -   **`void displayTitleWithSubtitles(const char* title, const char* leftSubtitle, const char* rightSubtitle)`**: Displays a main `title` centered towards the top, with two smaller subtitles at the bottom: one left-aligned (`leftSubtitle`) and one right-aligned (`rightSubtitle`).
 
 #### Interactive UI Modes
--   **`void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint32_t color = 0xFFFF)`**: Renders an interactive selection screen. The `selectionItem` can be rendered in a specific `color` (defaulting to White) to highlight player identities during setup.
--   **`void displayCharacterInput(const char* currentName, int activeIndex, uint32_t color = 0xFFFF)`**: Renders an interactive screen for name input, with the active character highlighted in the provided `color`.
+-   **`void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue = 0xFFFF)`**: Renders an interactive selection screen. The `selectionItem` can be rendered in a specific `hue` (defaulting to White) to highlight player identities during setup.
+-   **`void displayCharacterInput(const char* currentName, int activeIndex, uint16_t hue = 0xFFFF)`**: Renders an interactive screen for name input, with the active character highlighted in the provided `hue`.
 
 ### Key Logic & Behavior
--   **Unified Color Identity**: By accepting `uint32_t` color values, the LCD can match the text and UI elements to the specific hue assigned to the current player on the LED grid.
+-   **Unified Color Identity**: By accepting `uint16_t` hue values, the LCD can match the text and UI elements to the specific hue assigned to the current player on the LED grid, directly mapping standard color values to RGB565.
 -   **Hardware SPI Bus**: Uses the Uno R4's hardware SPI (D11/D13) for zero-latency UI updates. It shares this bus with the `ScoreDisplay` (MAX7219) but uses a dedicated **CS (A4)** pin.
 -   **Control Pins**:
     -   **CS (A4)**: Chip Select.

--- a/design/SCHEMATIC_AND_HARDWARE_GUIDE.md
+++ b/design/SCHEMATIC_AND_HARDWARE_GUIDE.md
@@ -246,11 +246,11 @@ void setup() {
   pinMode(LCD_BLK_PIN, OUTPUT);
   digitalWrite(LCD_BLK_PIN, HIGH); // Turn on screen
 
-  // ... Initialize Score Display (LedControl), LCD (Adafruit_ST7789), etc ...  
+  // ... Initialize Score Display (SPI), LCD (Adafruit_ST7789), etc ...
 }
 ```
 
-
+```cpp
 void loop() {  
   // Example Logic  
   // Update status strip based on game state

--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -184,7 +184,7 @@ To verify the performance and correctness of individual hardware components (lik
 ### 6.1 Strategy: "Double Mocking"
 We employ a two-layer mocking strategy to isolate different parts of the system:
 1.  **Game Logic Tests (`env:native`):** We mock the *Component* (e.g., `FakeScoreDisplay`). This assumes the component works and tests the game rules.
-2.  **Component Tests (`env:component_tests`):** We use the **REAL** component code (`ScoreDisplay.cpp`) but mock the **External Hardware Library** (e.g., `LedControl`).
+2.  **Component Tests (`env:component_tests`):** We use the **REAL** component code (`ScoreDisplay.cpp`, `TextDisplayV2.cpp`) but mock the **External Hardware Library** (e.g., `SPI.h`, `Adafruit_ST7789.h`).
 
 ### 6.2 Why this is needed
 *   **Hardware-Independent Correctness:** Verifies logic like "splitting a 5-digit number into characters" or "padding with spaces" works correctly before it touches a real chip.
@@ -199,23 +199,36 @@ pio test -e component_tests
 ### 6.4 Directory Structure
 *   `test/test_component_*/`: Contains the test suites for components (e.g., `test_component_score_display/`, `test_component_led_progress_grid/`).
     *   **Note on Subdirectories**: Individual components have their own test subdirectories to avoid linker conflicts. The Unity framework's `setUp`, `tearDown`, and `main` functions would otherwise cause multiple-definition errors when compiling all component tests into a single test runner.
-*   `test/mocks/libs/`: Contains mocks for external libraries (e.g., `LedControl.h`, `Adafruit_NeoPixel.h`) used by components.
+*   `test/mocks/libs/`: Contains mocks for external libraries (e.g., `SPI.h`, `Adafruit_NeoPixel.h`, `Adafruit_ST7789.h`) used by components.
 
 ### 6.5 Example Test Cases: `ScoreDisplay`
 *   **`test_ScoreDisplay_Correctness_Overflow`**: Verifies that numbers greater than 99,999 are capped and displayed as "99999".
 *   **`test_ScoreDisplay_Blinking_Intensity`**: Verifies that when `blink` is enabled, calling `print_number` (which should be called every frame) results in the intensity toggling between `SCORE_BLINK_LOW` (2) and `SCORE_BLINK_HIGH` (12) as time advances.
+*   **`test_ScoreDisplay_HardwareInteractionOptimization`**: Verifies that the internal state caching prevents redundant hardware calls when the requested state (number, blink mode, intensity) has not changed.
+*   **`test_ScoreDisplay_Performance`**: Benchmarks the execution time of repeated display updates to ensure high-speed SPI transactions perform adequately in critical loops.
+*   **`test_ScoreDisplay_Security_InvalidType`**: Verifies that passing an invalid `DisplayType` enum value does not crash the system and is gracefully rejected.
+*   **`test_ScoreDisplay_Security_NegativeOverflow`**: Verifies that deeply negative numbers (e.g., -12345, which would require 6 digits including the sign) are clamped to `-9999` to prevent out-of-bounds memory writes when formatting the display segments.
 
-### 6.6 Example Test Cases: `ControlPad`
+### 6.6 Example Test Cases: `TextDisplayV2`
+*   **`test_begin`**: Verifies that the display initialization sequence correctly configures the Adafruit ST7789 library (init, setRotation, fillScreen).
+*   **`test_print`**: Verifies that `print()` passes the correct text content and mapped RGB565 color to the underlying Adafruit display graphics API.
+*   **`test_print_caching`**: Verifies that repeated calls to `print()` with the exact same text and color do not trigger redundant hardware rendering.
+*   **`test_printSelectionScreen`**: Verifies that the selection screen correctly renders both the title text and the item text, along with generating the geometric up/down arrow indicators.
+*   **`test_mode_switching`**: Verifies that transitioning between different display modes (e.g., MESSAGE to SELECTION) correctly invalidates the cache and forces a full screen redraw even if text overlaps.
+*   **`test_selection_screen_caching`**: Verifies that state caching works correctly for the interactive selection screen to optimize layout updates.
+*   **`test_colorHSVtoRGB565`**: Verifies that the custom, lightweight hue-to-RGB565 math correctly converts extreme inputs, mapping Hue 0 correctly to Red (0xF800).
+
+### 6.7 Example Test Cases: `ControlPad`
 *   **`test_add_valid_button`**: Verifies that adding a button with a valid pin correctly configures the pin mode to `INPUT_PULLUP`.
 *   **`test_add_invalid_pin_negative`**: Verifies that adding a button with a negative pin index is ignored and does not corrupt memory or configure hardware.
 *   **`test_read_valid_button`**: Verifies that reading the control pad correctly detects a button press (LOW state) and returns the associated action.
 
-### 6.7 Example Test Cases: `LedProgressGrid`
+### 6.8 Example Test Cases: `LedProgressGrid`
 *   **`test_LedProgressGrid_MaxScore_Exact`**: Verifies that `_maxScore` scales exactly to the highest score (if above target) rather than jumping by fixed increments.
 *   **`test_LedProgressGrid_MaxScore_IncludesAtRisk`**: Verifies that the dynamic grid maximum correctly incorporates the current player's at-risk points.
 *   **`test_LedProgressGrid_MaxScore_Shrinking`**: Verifies that the grid bounds can shrink back to the target score if a leading player farkles or a turn ends without banking.
 
-### 6.8 Example Test Cases: `FarkleWarningLights`
+### 6.9 Example Test Cases: `FarkleWarningLights`
 *   **`test_Update_SetsCorrectColorsAndBrightness`**: Verifies that the component correctly sets NeoPixel colors and brightness based on player status (Active/Idle) and farkle count (0: White/Off, 1: Yellow, 2+: Red).
 *   **`test_MultiLedMapping`**: Verifies that the component uses the shared `PlayerLayout` to map a single player to multiple LEDs when fewer than 8 players are present.
 *   **`test_BlinkLogic`**: Verifies that the active player's LEDs blink (toggle On/Off) based on the `isBlinking` parameter, while idle players remain solid.


### PR DESCRIPTION
The design docs now accurately reflect the implemented Step 3 migration.
- `ScoreDisplay` is properly defined as using `SPI` and omitting `LedControl`.
- `TextDisplayV2` properly lists the `hue` parameters on its print functions.
- `TESTING_STRATEGY.md` incorporates the missing missing `ScoreDisplay` tests and a new section for the missing `TextDisplayV2` tests.

---
*PR created automatically by Jules for task [3261331685370639468](https://jules.google.com/task/3261331685370639468) started by @gwenrich136*