### PR TITLE
UI update: Larger and thicker selection arrows for TextDisplayV2

### DIFF
--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
@@ -4,9 +4,9 @@
 #include <cstring>
 
 // Arrow geometry
-#define ARROW_WIDTH 10
-#define ARROW_HEIGHT 6
-#define ARROW_SPACING 10
+#define ARROW_WIDTH 20
+#define ARROW_HEIGHT 12
+#define ARROW_SPACING 15
 
 TextDisplayV2::TextDisplayV2(int cs, int dc, int res, int blk)
     : _display(cs, dc, res), _blkPin(blk), _currentMode(DisplayModeV2::NONE), _lastHue(0xFFFF)
@@ -109,15 +109,20 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
 void TextDisplayV2::drawArrow(int x, int y, bool up, uint16_t color) {
     int halfW = ARROW_WIDTH / 2;
     int halfH = ARROW_HEIGHT / 2;
+    int thickness = 3;
 
     if (up) {
-        // Tip (x, y-halfH), Left (x-halfW, y+halfH), Right (x+halfW, y+halfH)
-        _display.drawLine(x - halfW, y + halfH, x, y - halfH, color);
-        _display.drawLine(x + halfW, y + halfH, x, y - halfH, color);
+        for (int i = 0; i < thickness; i++) {
+            // Tip (x, y-halfH+i), Left (x-halfW, y+halfH+i), Right (x+halfW, y+halfH+i)
+            _display.drawLine(x - halfW, y + halfH + i, x, y - halfH + i, color);
+            _display.drawLine(x + halfW, y + halfH + i, x, y - halfH + i, color);
+        }
     } else {
-        // Tip (x, y+halfH), Left (x-halfW, y-halfH), Right (x+halfW, y-halfH)
-        _display.drawLine(x - halfW, y - halfH, x, y + halfH, color);
-        _display.drawLine(x + halfW, y - halfH, x, y + halfH, color);
+        for (int i = 0; i < thickness; i++) {
+            // Tip (x, y+halfH-i), Left (x-halfW, y-halfH-i), Right (x+halfW, y-halfH-i)
+            _display.drawLine(x - halfW, y - halfH - i, x, y + halfH - i, color);
+            _display.drawLine(x + halfW, y - halfH - i, x, y + halfH - i, color);
+        }
     }
 }
 

--- a/src/farkle/test/test_component_text_display/test_TextDisplayV2.cpp
+++ b/src/farkle/test/test_component_text_display/test_TextDisplayV2.cpp
@@ -75,8 +75,8 @@ void test_printSelectionScreen(void) {
         TEST_ASSERT_EQUAL_STRING("Player 1", mockAdafruitPrintCalls[1].str.c_str());
     }
 
-    // Verify arrows (2 lines per arrow, 2 arrows = 4 lines)
-    TEST_ASSERT_EQUAL(4, mockAdafruitDrawLineCalls.size());
+    // Verify arrows (2 lines per arrow side, 3 thickness lines per side, 2 sides, 2 arrows = 12 lines)
+    TEST_ASSERT_EQUAL(12, mockAdafruitDrawLineCalls.size());
 }
 
 void test_mode_switching(void) {


### PR DESCRIPTION
💡 What
Increased the size and thickness of the arrows rendered on the selection screen of TextDisplayV2. Adjusted dimensions to 20x12 with 15px spacing, and implemented a 3-line thick chevron approach. Updated the relevant component tests.

🎯 Why
A recent font update resulted in the selection screen arrows appearing too small and thin relative to the text.

📊 Measured Improvement
Visual update with unit test coverage updated accordingly.

---
*PR created automatically by Jules for task [3134957548910566184](https://jules.google.com/task/3134957548910566184) started by @gwenrich136*