### PR TITLE
Eliminate full-screen flicker on TextDisplayV2 updates

### DIFF
--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
@@ -36,13 +36,25 @@ void TextDisplayV2::print(const char* message, uint16_t hue)
   if (_currentMode == DisplayModeV2::MESSAGE && strcmp(_lastMessage, message) == 0 && _lastHue == hue) {
     return; // State cache
   }
+
+  _display.setFont(&FreeSans18pt7b);
+
+  if (_currentMode == DisplayModeV2::MESSAGE) {
+    // Erase old message
+    int16_t oldX1, oldY1;
+    uint16_t oldW, oldH;
+    _display.getTextBounds(_lastMessage, 0, 0, &oldX1, &oldY1, &oldW, &oldH);
+    int16_t oldX = LCD_CENTER_X - (oldW / 2);
+    int16_t oldY = LCD_CENTER_Y + (oldH / 2);
+    _display.fillRect(oldX + oldX1, oldY + oldY1, oldW, oldH, ST77XX_BLACK);
+  } else {
+    _display.fillScreen(ST77XX_BLACK);
+  }
+
   _currentMode = DisplayModeV2::MESSAGE;
   strncpy(_lastMessage, message, sizeof(_lastMessage) - 1);
   _lastMessage[sizeof(_lastMessage) - 1] = '\0';
   _lastHue = hue;
-
-  _display.fillScreen(ST77XX_BLACK);
-  _display.setFont(&FreeSans18pt7b);
 
   uint16_t textColor = (hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(hue);
   _display.setTextColor(textColor);
@@ -66,6 +78,25 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
         _lastHue == hue) {
         return; // State cache
     }
+
+    _display.setFont(&FreeSans18pt7b);
+
+    bool titleChanged = strcmp(_lastTitle, selectionTitle) != 0;
+    bool modeChanged = _currentMode != DisplayModeV2::SELECTION;
+
+    if (!modeChanged && !titleChanged) {
+        // Only the item changed. Erase the old item.
+        int16_t oldX1, oldY1;
+        uint16_t oldW, oldH;
+        _display.getTextBounds(_lastItem, 0, 0, &oldX1, &oldY1, &oldW, &oldH);
+        int16_t oldX = LCD_CENTER_X - (oldW / 2);
+        int16_t oldY = LCD_CENTER_Y + (oldH / 2);
+        _display.fillRect(oldX + oldX1, oldY + oldY1, oldW, oldH, ST77XX_BLACK);
+    } else {
+        // Mode or title changed, need full wipe and redraw of static elements
+        _display.fillScreen(ST77XX_BLACK);
+    }
+
     _currentMode = DisplayModeV2::SELECTION;
     strncpy(_lastTitle, selectionTitle, sizeof(_lastTitle) - 1);
     _lastTitle[sizeof(_lastTitle) - 1] = '\0';
@@ -73,24 +104,23 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
     _lastItem[sizeof(_lastItem) - 1] = '\0';
     _lastHue = hue;
 
-    _display.fillScreen(ST77XX_BLACK);
-    _display.setFont(&FreeSans18pt7b);
-
     // Resolve color
     uint16_t itemColor = (hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(hue);
 
     int16_t x1, y1;
     uint16_t w, h;
 
-    // Title
-    _display.getTextBounds(selectionTitle, 0, 0, &x1, &y1, &w, &h);
-    int16_t titleX = LCD_CENTER_X - (w / 2);
-    int16_t titleY = 40; // Fixed top margin
-    _display.setTextColor(ST77XX_WHITE);
-    _display.setCursor(titleX, titleY);
-    _display.print(selectionTitle);
+    // Title (only draw if it changed or mode changed)
+    if (modeChanged || titleChanged) {
+        _display.getTextBounds(selectionTitle, 0, 0, &x1, &y1, &w, &h);
+        int16_t titleX = LCD_CENTER_X - (w / 2);
+        int16_t titleY = 40; // Fixed top margin
+        _display.setTextColor(ST77XX_WHITE);
+        _display.setCursor(titleX, titleY);
+        _display.print(selectionTitle);
+    }
 
-    // Item
+    // Item (always draw since we erased it or did a full screen fill)
     _display.getTextBounds(selectionItem, 0, 0, &x1, &y1, &w, &h);
     int16_t itemX = LCD_CENTER_X - (w / 2);
     int16_t itemY = LCD_CENTER_Y + (h / 2); // Center vertically
@@ -98,12 +128,14 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
     _display.setCursor(itemX, itemY);
     _display.print(selectionItem);
 
-    // Arrows
-    int upArrowY = itemY - h - ARROW_SPACING;
-    int downArrowY = itemY + ARROW_SPACING;
+    // Arrows (only draw if mode or title changed, otherwise they are still there)
+    if (modeChanged || titleChanged) {
+        int upArrowY = itemY - h - ARROW_SPACING;
+        int downArrowY = itemY + ARROW_SPACING;
 
-    drawArrow(LCD_CENTER_X, upArrowY, true, ST77XX_WHITE);
-    drawArrow(LCD_CENTER_X, downArrowY, false, ST77XX_WHITE);
+        drawArrow(LCD_CENTER_X, upArrowY, true, ST77XX_WHITE);
+        drawArrow(LCD_CENTER_X, downArrowY, false, ST77XX_WHITE);
+    }
 }
 
 void TextDisplayV2::drawArrow(int x, int y, bool up, uint16_t color) {

--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
@@ -33,41 +33,35 @@ void TextDisplayV2::begin() {
 
 void TextDisplayV2::print(const char* message, uint16_t hue)
 {
-  if (_currentMode == DisplayModeV2::MESSAGE && strcmp(_lastMessage, message) == 0 && _lastHue == hue) {
-    return; // State cache
-  }
+    if (_currentMode == DisplayModeV2::MESSAGE && strcmp(_lastMessage, message) == 0 && _lastHue == hue) {
+        return;
+    }
 
-  _display.setFont(&FreeSans18pt7b);
+    _display.setFont(&FreeSans18pt7b);
 
-  if (_currentMode == DisplayModeV2::MESSAGE) {
-    // Erase old message
-    int16_t oldX1, oldY1;
-    uint16_t oldW, oldH;
-    _display.getTextBounds(_lastMessage, 0, 0, &oldX1, &oldY1, &oldW, &oldH);
-    int16_t oldX = LCD_CENTER_X - (oldW / 2);
-    int16_t oldY = LCD_CENTER_Y + (oldH / 2);
-    _display.fillRect(oldX + oldX1, oldY + oldY1, oldW, oldH, ST77XX_BLACK);
-  } else {
-    _display.fillScreen(ST77XX_BLACK);
-  }
+    if (_currentMode == DisplayModeV2::MESSAGE) {
+        eraseOldTextBoundingBox(_lastMessage);
+    } else {
+        _display.fillScreen(ST77XX_BLACK);
+    }
 
-  _currentMode = DisplayModeV2::MESSAGE;
-  strncpy(_lastMessage, message, sizeof(_lastMessage) - 1);
-  _lastMessage[sizeof(_lastMessage) - 1] = '\0';
-  _lastHue = hue;
+    _currentMode = DisplayModeV2::MESSAGE;
+    strncpy(_lastMessage, message, sizeof(_lastMessage) - 1);
+    _lastMessage[sizeof(_lastMessage) - 1] = '\0';
+    _lastHue = hue;
 
-  uint16_t textColor = (hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(hue);
-  _display.setTextColor(textColor);
+    uint16_t textColor = (hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(hue);
+    _display.setTextColor(textColor);
 
-  int16_t x1, y1;
-  uint16_t w, h;
-  _display.getTextBounds(message, 0, 0, &x1, &y1, &w, &h);
+    int16_t x1, y1;
+    uint16_t w, h;
+    _display.getTextBounds(message, 0, 0, &x1, &y1, &w, &h);
 
-  int16_t x = LCD_CENTER_X - (w / 2);
-  int16_t y = LCD_CENTER_Y + (h / 2); // FreeType fonts draw from baseline, so we adjust Y down
+    int16_t x = LCD_CENTER_X - (w / 2);
+    int16_t y = LCD_CENTER_Y + (h / 2); // FreeType fonts draw from baseline, so we adjust Y down
 
-  _display.setCursor(x, y);
-  _display.print(message);
+    _display.setCursor(x, y);
+    _display.print(message);
 }
 
 void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue)
@@ -76,24 +70,18 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
         strcmp(_lastTitle, selectionTitle) == 0 &&
         strcmp(_lastItem, selectionItem) == 0 &&
         _lastHue == hue) {
-        return; // State cache
+        return;
     }
 
     _display.setFont(&FreeSans18pt7b);
 
     bool titleChanged = strcmp(_lastTitle, selectionTitle) != 0;
     bool modeChanged = _currentMode != DisplayModeV2::SELECTION;
+    bool needsFullRedraw = modeChanged || titleChanged;
 
-    if (!modeChanged && !titleChanged) {
-        // Only the item changed. Erase the old item.
-        int16_t oldX1, oldY1;
-        uint16_t oldW, oldH;
-        _display.getTextBounds(_lastItem, 0, 0, &oldX1, &oldY1, &oldW, &oldH);
-        int16_t oldX = LCD_CENTER_X - (oldW / 2);
-        int16_t oldY = LCD_CENTER_Y + (oldH / 2);
-        _display.fillRect(oldX + oldX1, oldY + oldY1, oldW, oldH, ST77XX_BLACK);
+    if (!needsFullRedraw) {
+        eraseOldTextBoundingBox(_lastItem);
     } else {
-        // Mode or title changed, need full wipe and redraw of static elements
         _display.fillScreen(ST77XX_BLACK);
     }
 
@@ -104,38 +92,58 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
     _lastItem[sizeof(_lastItem) - 1] = '\0';
     _lastHue = hue;
 
-    // Resolve color
     uint16_t itemColor = (hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(hue);
+    int16_t itemY;
+    uint16_t itemH;
 
+    if (needsFullRedraw) {
+        drawSelectionTitle(selectionTitle);
+    }
+
+    drawSelectionItem(selectionItem, itemColor, itemY, itemH);
+
+    if (needsFullRedraw) {
+        drawSelectionArrows(itemY, itemH);
+    }
+}
+
+void TextDisplayV2::eraseOldTextBoundingBox(const char* text) {
+    int16_t oldX1, oldY1;
+    uint16_t oldW, oldH;
+    _display.getTextBounds(text, 0, 0, &oldX1, &oldY1, &oldW, &oldH);
+    int16_t oldX = LCD_CENTER_X - (oldW / 2);
+    int16_t oldY = LCD_CENTER_Y + (oldH / 2);
+    _display.fillRect(oldX + oldX1, oldY + oldY1, oldW, oldH, ST77XX_BLACK);
+}
+
+void TextDisplayV2::drawSelectionTitle(const char* title) {
     int16_t x1, y1;
     uint16_t w, h;
+    _display.getTextBounds(title, 0, 0, &x1, &y1, &w, &h);
+    int16_t titleX = LCD_CENTER_X - (w / 2);
+    int16_t titleY = 40; // Fixed top margin
+    _display.setTextColor(ST77XX_WHITE);
+    _display.setCursor(titleX, titleY);
+    _display.print(title);
+}
 
-    // Title (only draw if it changed or mode changed)
-    if (modeChanged || titleChanged) {
-        _display.getTextBounds(selectionTitle, 0, 0, &x1, &y1, &w, &h);
-        int16_t titleX = LCD_CENTER_X - (w / 2);
-        int16_t titleY = 40; // Fixed top margin
-        _display.setTextColor(ST77XX_WHITE);
-        _display.setCursor(titleX, titleY);
-        _display.print(selectionTitle);
-    }
-
-    // Item (always draw since we erased it or did a full screen fill)
-    _display.getTextBounds(selectionItem, 0, 0, &x1, &y1, &w, &h);
+void TextDisplayV2::drawSelectionItem(const char* item, uint16_t color, int16_t& itemY, uint16_t& itemH) {
+    int16_t x1, y1;
+    uint16_t w;
+    _display.getTextBounds(item, 0, 0, &x1, &y1, &w, &itemH);
     int16_t itemX = LCD_CENTER_X - (w / 2);
-    int16_t itemY = LCD_CENTER_Y + (h / 2); // Center vertically
-    _display.setTextColor(itemColor);
+    itemY = LCD_CENTER_Y + (itemH / 2); // Center vertically
+    _display.setTextColor(color);
     _display.setCursor(itemX, itemY);
-    _display.print(selectionItem);
+    _display.print(item);
+}
 
-    // Arrows (only draw if mode or title changed, otherwise they are still there)
-    if (modeChanged || titleChanged) {
-        int upArrowY = itemY - h - ARROW_SPACING;
-        int downArrowY = itemY + ARROW_SPACING;
+void TextDisplayV2::drawSelectionArrows(int16_t itemY, uint16_t itemH) {
+    int upArrowY = itemY - itemH - ARROW_SPACING;
+    int downArrowY = itemY + ARROW_SPACING;
 
-        drawArrow(LCD_CENTER_X, upArrowY, true, ST77XX_WHITE);
-        drawArrow(LCD_CENTER_X, downArrowY, false, ST77XX_WHITE);
-    }
+    drawArrow(LCD_CENTER_X, upArrowY, true, ST77XX_WHITE);
+    drawArrow(LCD_CENTER_X, downArrowY, false, ST77XX_WHITE);
 }
 
 void TextDisplayV2::drawArrow(int x, int y, bool up, uint16_t color) {

--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.h
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.h
@@ -43,6 +43,10 @@ class TextDisplayV2
     char _lastItem[32];
     uint16_t _lastHue;
 
+    void eraseOldTextBoundingBox(const char* text);
+    void drawSelectionTitle(const char* title);
+    void drawSelectionItem(const char* item, uint16_t color, int16_t& itemY, uint16_t& itemH);
+    void drawSelectionArrows(int16_t itemY, uint16_t itemH);
     void drawArrow(int x, int y, bool up, uint16_t color);
 };
 


### PR DESCRIPTION
Eliminate full-screen flicker on TextDisplayV2 updates

Refactored the `print` and `printSelectionScreen` methods in `TextDisplayV2` to erase only the bounding box of the old text using a black `fillRect()`, instead of wiping the entire screen with `fillScreen()`. This prevents the "flash" effect while using the custom `FreeSans18pt7b` font. In selection screens, the update intelligently preserves static assets (title and arrows) if only the selection item changes, providing a perfectly smooth scrolling experience.

---
*PR created automatically by Jules for task [12465222633142134964](https://jules.google.com/task/12465222633142134964) started by @gwenrich136*