### PR TITLE
Add EndOfTurnPhase for unified turn transitions

### DIFF
--- a/design/IN_GAME_PHASES.md
+++ b/design/IN_GAME_PHASES.md
@@ -14,7 +14,8 @@ This category handles user input for scoring, provides feedback through animatio
 - `WaitingPhase` -> `BankingPhase` (on Bank button)
 - `WaitingPhase` -> `FarklingPhase` (on Farkle button)
 - `WaitingPhase` -> `PenaltyFarklingPhase` (on 3rd consecutive Farkle)
-- All animation phases (`BankingPhase`, `FarklingPhase`, `PenaltyFarklingPhase`) return to `WaitingPhase` after completion and a button press.
+- All animation phases (`BankingPhase`, `FarklingPhase`, `PenaltyFarklingPhase`) return to `EndOfTurnPhase` after animation completion.
+- `EndOfTurnPhase` returns to `WaitingPhase` after a button press.
 - `WaitingPhase` transitions to `PostGamePhase_V1` when a player reaches the target score and the final round completes.
 
 ## 4. Technical Details
@@ -34,11 +35,7 @@ This category handles user input for scoring, provides feedback through animatio
 *   **Implementation Details:**
     0.  **Reset Farkle Count:** The `onEnter()` method resets the current player's `farkle_count` to 0.
     1.  **Animate Score Transfer:** While `state.atRiskScore > 0`, run the time-based animation logic using `deltaTime` to incrementally move points from `state.atRiskScore` to the current player's banked score. Ignore all input during this stage.
-    2.  **Wait for Dismissal:** Once `state.atRiskScore == 0`, the animation is complete. The game persists in this state and waits for `input.action != NONE`. This allows players to review the final score.
-    3.  **Finalize Turn:** Once a button is pressed:
-        a. **Check for Final Round Trigger:** Check if `!state.finalRoundTriggered` and if any player's score is now `>= state.targetScore`. If so, set `state.finalRoundTriggered = true;`.
-        b. Call the shared helper `this->endTurn(state);` to advance the `currentPlayerIndex`.
-        c. `return game.getPhase<WaitingPhase>();`.
+    2.  **Transition:** Once `state.atRiskScore == 0`, the animation is complete and returns `game.getPhase<EndOfTurnPhase>()`.
 
 ### FarklingPhase
 *   **Why:** Implements the farkle animation and the end-of-turn logic.
@@ -46,10 +43,7 @@ This category handles user input for scoring, provides feedback through animatio
 *   **Implementation Details:**
     1.  **Increment Count:** The `onEnter()` method checks if `player.score > 0`. If true, it increments the `farkle_count`. If false (score is 0), the count is **not** incremented ("No Harm, No Foul").
     2.  **Animate Score Loss:** The `update()` method runs a time-based animation to drain `state.atRiskScore` to 0. It ignores input during the animation.
-    3.  **Wait for Dismissal:** Once `state.atRiskScore == 0`, wait for `input.action != NONE`.
-    3.  **Finalize Turn:** Upon button press:
-        a. Call the shared helper `this->endTurn(state);` to advance the `currentPlayerIndex`.
-        b. `return game.getPhase<WaitingPhase>();`.
+    3.  **Transition:** Once `state.atRiskScore == 0`, the animation is complete and returns `game.getPhase<EndOfTurnPhase>()`.
 
 ### PenaltyFarklingPhase
 *   **Why:** Implements the catastrophic farkle penalty for a player's third consecutive farkle.
@@ -63,8 +57,17 @@ This category handles user input for scoring, provides feedback through animatio
     2.  **3-Stage Animation (`update()`):**
         *   **Stage 1: The Pain (0s - 5s):** No score changes. `atRisk` display is set to blink/flash. Warning lights alternate.
         *   **Stage 2: The Drain:** `atRisk` display stops blinking. Values animate: `atRisk` goes up to 0, Banked score goes down. Warning lights continue alternating.
-        *   **Stage 3: The Wait:** Animation complete. Warning lights turn OFF. Wait for button press.
-    3.  **Finalize Turn:** Upon button press, call `endTurn(state)` and `return game.getPhase<WaitingPhase>();`.
+        *   **Stage 3: The Wait:** Animation complete. Warning lights turn OFF. Transitions to `EndOfTurnPhase`.
+
+### EndOfTurnPhase
+*   **Why:** Implements a single unified state to wait for turn dismissal across all in-game scoring outcomes.
+*   **Defined in:** `src/farkle/include/phases/EndOfTurnPhase.h` & `src/farkle/src/phases/EndOfTurnPhase.cpp`
+*   **Implementation Details:**
+    1.  **Wait for Dismissal:** The `update()` method waits for any button press (`input.action != NONE`).
+    2.  **Finalize Turn:** Once a button is pressed:
+        a. Check if `!state.finalRoundTriggered` and if the current player's score is now `>= state.targetScore`. If so, set `state.finalRoundTriggered = true;`.
+        b. Call the shared helper `this->endTurn(state);` to advance the `currentPlayerIndex`.
+        c. `return game.getPhase<WaitingPhase>();`.
 
 *   **Refactoring Note:** To support the unique display requirements (flashing score, alternating lights, and conditional at-risk display), `InGamePhase::display()` is refactored into smaller virtual hooks:
     *   `updateWarningLights()`: Collects the `farkle_count` for all players and the `currentPlayerIndex`. It passes this data to the `FarkleWarningLights` component to update the entire 8-LED Status Strip (current player flashing, others dim/solid).

--- a/src/farkle/include/Game.h
+++ b/src/farkle/include/Game.h
@@ -14,6 +14,7 @@
 #include "phases/FarklingPhase.h"
 #include "phases/PenaltyFarklingPhase.h"
 #include "phases/PostGamePhase_V1.h"
+#include "phases/EndOfTurnPhase.h"
 
 // Hardware Component Includes
 #include "ControlPad.h"
@@ -38,6 +39,7 @@ public:
         if (std::is_same<T, FarklingPhase>::value) return (T*)&phasePool.farkling;
         if (std::is_same<T, PenaltyFarklingPhase>::value) return (T*)&phasePool.penaltyFarkling;
         if (std::is_same<T, PostGamePhase_V1>::value) return (T*)&phasePool.postGame;
+        if (std::is_same<T, EndOfTurnPhase>::value) return (T*)&phasePool.endOfTurn;
         return nullptr;
     }
 
@@ -59,6 +61,7 @@ private:
         FarklingPhase farkling;
         PenaltyFarklingPhase penaltyFarkling;
         PostGamePhase_V1 postGame;
+        EndOfTurnPhase endOfTurn;
     };
 
     PhasePool phasePool;

--- a/src/farkle/include/phases/EndOfTurnPhase.h
+++ b/src/farkle/include/phases/EndOfTurnPhase.h
@@ -1,0 +1,17 @@
+#ifndef EndOfTurnPhase_h
+#define EndOfTurnPhase_h
+
+#include "GamePhase.h"
+
+class EndOfTurnPhase : public InGamePhase {
+public:
+    virtual ~EndOfTurnPhase() = default;
+    virtual void onEnter(GameState& state) override;
+    virtual GamePhase* update(Game& game, GameState& state, GameInput input, unsigned long deltaTime) override;
+
+protected:
+    virtual void updateAtRiskScoreDisplay(const GameState& state, const Displays& displays) override;
+    virtual void updateTextDisplay(const GameState& state, const Displays& displays) override;
+};
+
+#endif

--- a/src/farkle/src/phases/BankingPhase.cpp
+++ b/src/farkle/src/phases/BankingPhase.cpp
@@ -30,18 +30,7 @@ GamePhase* BankingPhase::update(Game& game, GameState& state, GameInput input, u
     // 2. Check for completion
     if (state.atRiskScore <= 0) {
         state.atRiskScore = 0; // Clean up any fractional remainder
-
-        // Wait for user dismissal (any button press)
-        if (input.action != ButtonAction::NONE) {
-            // Check for Final Round Trigger
-            if (!state.finalRoundTriggered && state.players[state.currentPlayerIndex].score >= state.targetScore) {
-                state.finalRoundTriggered = true;
-            }
-
-            // Advance turn and transition
-            this->endTurn(state);
-            return game.getPhase<WaitingPhase>();
-        }
+        return game.getPhase<EndOfTurnPhase>();
     }
 
     return this;

--- a/src/farkle/src/phases/EndOfTurnPhase.cpp
+++ b/src/farkle/src/phases/EndOfTurnPhase.cpp
@@ -1,0 +1,34 @@
+#include "phases/EndOfTurnPhase.h"
+#include "Game.h"
+#include <assert.h>
+
+void EndOfTurnPhase::onEnter(GameState& state) {
+    // Phase starts when animation is over.
+    // Assert that the animation phase cleaned up the atRiskScore
+    assert(state.atRiskScore == 0 && "atRiskScore must be 0 when entering EndOfTurnPhase");
+}
+
+GamePhase* EndOfTurnPhase::update(Game& game, GameState& state, GameInput input, unsigned long deltaTime) {
+    // Wait for user dismissal (any button press)
+    if (input.action != ButtonAction::NONE) {
+        // Check for Final Round Trigger
+        if (!state.finalRoundTriggered && state.players[state.currentPlayerIndex].score >= state.targetScore) {
+            state.finalRoundTriggered = true;
+        }
+
+        // Advance turn and transition
+        this->endTurn(state);
+        return game.getPhase<WaitingPhase>();
+    }
+
+    return this;
+}
+
+void EndOfTurnPhase::updateAtRiskScoreDisplay(const GameState& state, const Displays& displays) {
+    // Explicitly clear the at risk score display once the turn ends
+    displays.scoreDisplay.clear(ScoreDisplay::DisplayType::AT_RISK_SCORE);
+}
+
+void EndOfTurnPhase::updateTextDisplay(const GameState& state, const Displays& displays) {
+    // Do nothing. Maintain the text from the previous phase.
+}

--- a/src/farkle/src/phases/FarklingPhase.cpp
+++ b/src/farkle/src/phases/FarklingPhase.cpp
@@ -30,12 +30,7 @@ GamePhase* FarklingPhase::update(Game& game, GameState& state, GameInput input, 
     // 2. Check for completion
     if (state.atRiskScore <= 0) {
         state.atRiskScore = 0;
-
-        // Wait for user dismissal
-        if (input.action != ButtonAction::NONE) {
-            this->endTurn(state);
-            return game.getPhase<WaitingPhase>();
-        }
+        return game.getPhase<EndOfTurnPhase>();
     }
 
     return this;

--- a/src/farkle/src/phases/PenaltyFarklingPhase.cpp
+++ b/src/farkle/src/phases/PenaltyFarklingPhase.cpp
@@ -54,12 +54,7 @@ GamePhase* PenaltyFarklingPhase::update(Game& game, GameState& state, GameInput 
             break;
 
         case PenaltyStage::THE_AFTERMATH:
-            // Wait for user dismissal
-            if (input.action != ButtonAction::NONE) {
-                this->endTurn(state);
-                return game.getPhase<WaitingPhase>();
-            }
-            break;
+            return game.getPhase<EndOfTurnPhase>();
     }
 
     return this;
@@ -69,11 +64,7 @@ void PenaltyFarklingPhase::updateAtRiskScoreDisplay(const GameState& state, cons
     // Use the blink parameter provided by the updated ScoreDisplay library
     bool shouldBlink = (currentStage == PenaltyStage::THE_PAIN);
 
-    if (state.atRiskScore == 0) {
-        displays.scoreDisplay.clear(ScoreDisplay::DisplayType::AT_RISK_SCORE);
-    } else {
-        displays.scoreDisplay.print_number(state.atRiskScore, ScoreDisplay::DisplayType::AT_RISK_SCORE, shouldBlink);
-    }
+    displays.scoreDisplay.print_number(state.atRiskScore, ScoreDisplay::DisplayType::AT_RISK_SCORE, shouldBlink);
 }
 
 void PenaltyFarklingPhase::updateWarningLights(const GameState& state, const Displays& displays) {

--- a/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
+++ b/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
@@ -42,12 +42,14 @@ void test_FullGame_TripleFarkle() {
 
     // --- First Farkle ---
     simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateNoAction(game); // Process FarklingPhase and transition to EndOfTurn
     TEST_ASSERT_EQUAL_INT(1, game.state.players[0].farkle_count);
     simulateButtonPress(game, ButtonAction::CLEAR); // Dismiss
 
     // --- Second Farkle ---
     game.state.currentPlayerIndex = 0; // Go back to Player 1
     simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateNoAction(game); // Process FarklingPhase and transition to EndOfTurn
     TEST_ASSERT_EQUAL_INT(2, game.state.players[0].farkle_count);
     simulateButtonPress(game, ButtonAction::CLEAR); // Dismiss
 
@@ -61,12 +63,10 @@ void test_FullGame_TripleFarkle() {
 
     // --- Run the penalty animation ---
     // Needs to cover 5000ms PAIN + 1000ms DRAIN
-    GameInput noInput;
-    noInput.action = ButtonAction::NONE;
-    noInput.rotationDelta = 0;
-    for (int i = 0; i < 650; ++i) {
-        game.currentPhase->update(game, game.state, noInput, 10);
-    }
+    waitForScoreAnimation(game);
+    // Needs one more step to actually trigger the phase transition
+    simulateNoAction(game);
+
     TEST_ASSERT_EQUAL_INT(0, game.state.atRiskScore);
     TEST_ASSERT_EQUAL_INT(1500, game.state.players[0].score); // Final score is correct
 }
@@ -85,11 +85,13 @@ void test_FullGame_TripleFarkle_ScoreLessThanPenalty() {
     // --- First Farkle ---
     advance_to_player_zero(game);
     simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateNoAction(game); // Process FarklingPhase and transition to EndOfTurn
     simulateButtonPress(game, ButtonAction::CLEAR); // Dismiss
 
     // --- Second Farkle ---
     advance_to_player_zero(game);
     simulateButtonPress(game, ButtonAction::FARKLE);
+    simulateNoAction(game); // Process FarklingPhase and transition to EndOfTurn
     simulateButtonPress(game, ButtonAction::CLEAR); // Dismiss
 
     // --- Third Farkle - Trigger penalty ---
@@ -98,10 +100,14 @@ void test_FullGame_TripleFarkle_ScoreLessThanPenalty() {
     TEST_ASSERT_EQUAL_PTR(game.getPhase<PenaltyFarklingPhase>(), game.currentPhase);
 
     // --- Run the penalty animation ---
+    // Needs to cover 5000ms PAIN + 1000ms DRAIN
     waitForScoreAnimation(game);
+    // Needs one more step to actually trigger the phase transition
+    simulateNoAction(game);
+
     TEST_ASSERT_EQUAL_INT(0, game.state.atRiskScore);
 
-    // --- Dismiss the penalty phase ---
+    // Simulate button press to dismiss the EndOfTurn phase that should be active now
     simulateButtonPress(game, ButtonAction::CLEAR);
     TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
 
@@ -128,11 +134,11 @@ void test_FullGame_FinalRoundBlinking() {
     waitForScoreAnimation(game);
 
     // Verify it is NOT blinking yet because finalRoundTriggered is set after banking is dismissed
-    game.loop();
+    simulateNoAction(game);
     TEST_ASSERT_FALSE(game.state.finalRoundTriggered);
     TEST_ASSERT_FALSE(game.scoreDisplay.captured_blinks[ScoreDisplay::DisplayType::COMPETITION_SCORE]);
 
-    // Dismiss the banking phase
+    // Dismiss the EndOfTurn phase
     simulateButtonPress(game, ButtonAction::CLEAR);
 
     // Now finalRoundTriggered should be true
@@ -157,6 +163,7 @@ void run_full_game_tests() {
 void advance_to_player_zero(Game& game) {
     while (game.state.currentPlayerIndex != 0) {
         simulateButtonPress(game, ButtonAction::FARKLE); // A simple action to advance the turn
+        simulateNoAction(game); // Process FarklingPhase and transition to EndOfTurn
         simulateButtonPress(game, ButtonAction::CLEAR); // Dismiss the phase to complete the turn
     }
     TEST_ASSERT_EQUAL_INT(0, game.state.currentPlayerIndex);

--- a/src/farkle/test/test_game_logic/medium_tests/test_tie_breaking.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_tie_breaking.cpp
@@ -31,6 +31,7 @@ void test_TieBreaking_Case1() {
 
     // Player 2 Farkles
     simulateButtonPress(game, ButtonAction::FARKLE); // Enter FarklingPhase
+    simulateNoAction(game); // Process FarklingPhase and transition to EndOfTurn
     simulateButtonPress(game, ButtonAction::FARKLE); // Confirm Farkle and advance
     TEST_ASSERT_EQUAL_INT(2, game.state.currentPlayerIndex); // Player 3's turn
 

--- a/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_BankingPhase.cpp
@@ -50,19 +50,17 @@ void test_BankingPhase_InputSpamming() {
     TEST_ASSERT_EQUAL_PTR(game.getPhase<BankingPhase>(), game.currentPhase);
 }
 
-// Verifies that a button press transitions to the WaitingPhase after the banking animation is complete.
-void test_BankingPhase_ManualAdvance() {
+// Verifies that when atRiskScore reaches 0, it transitions to EndOfTurnPhase.
+void test_BankingPhase_TransitionsToEndOfTurn() {
     Game game;
     setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 0;
     game.currentPhase = game.getPhase<BankingPhase>();
 
     simulateNoAction(game);
-    TEST_ASSERT_EQUAL_PTR(game.getPhase<BankingPhase>(), game.currentPhase);
 
-    simulateButtonPress(game, ButtonAction::BANK);
-
-    TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
+    // As soon as atRiskScore is 0 and it updates, it transitions to EndOfTurnPhase
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<EndOfTurnPhase>(), game.currentPhase);
 }
 
 // Verifies that the farkle count is reset immediately upon entering the BankingPhase.
@@ -128,7 +126,7 @@ void run_banking_phase_tests() {
     RUN_TEST(test_BankingPhase_AnimationMath);
     RUN_TEST(test_BankingPhase_ZeroFloorSafety);
     RUN_TEST(test_BankingPhase_InputSpamming);
-    RUN_TEST(test_BankingPhase_ManualAdvance);
+    RUN_TEST(test_BankingPhase_TransitionsToEndOfTurn);
     RUN_TEST(test_BankingPhase_FarkleResetOnEnter);
     RUN_TEST(test_BankingPhase_LightsOffDuringAnimation);
     RUN_TEST(test_BankingPhase_FinalRoundBlinking);

--- a/src/farkle/test/test_game_logic/small_tests/test_EndOfTurnPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_EndOfTurnPhase.cpp
@@ -1,0 +1,78 @@
+#include "test_EndOfTurnPhase.h"
+#include "Game.h"
+#include "phases/EndOfTurnPhase.h"
+#include "phases/WaitingPhase.h"
+#include "../test_utils.h"
+#include <unity.h>
+#include "Arduino.h"
+
+// Verifies that a button press advances the turn and transitions to WaitingPhase
+void test_EndOfTurnPhase_ManualAdvance() {
+    Game game;
+    setupGameWithPlayers(game, 4);
+    game.state.atRiskScore = 0;
+    game.state.currentPlayerIndex = 0;
+    game.currentPhase = game.getPhase<EndOfTurnPhase>();
+    game.currentPhase->onEnter(game.state);
+
+    simulateNoAction(game);
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<EndOfTurnPhase>(), game.currentPhase);
+    TEST_ASSERT_EQUAL_INT(0, game.state.currentPlayerIndex);
+
+    simulateButtonPress(game, ButtonAction::CLEAR);
+
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
+    TEST_ASSERT_EQUAL_INT(1, game.state.currentPlayerIndex);
+}
+
+// Verifies that the phase correctly triggers final round if score condition met
+void test_EndOfTurnPhase_FinalRoundTrigger() {
+    Game game;
+    setupGameWithPlayers(game, 4);
+    game.state.atRiskScore = 0;
+    game.state.targetScore = 10000;
+    game.state.players[0].score = 10000;
+    game.state.currentPlayerIndex = 0;
+    game.currentPhase = game.getPhase<EndOfTurnPhase>();
+    game.currentPhase->onEnter(game.state);
+
+    simulateButtonPress(game, ButtonAction::BANK);
+
+    TEST_ASSERT_TRUE(game.state.finalRoundTriggered);
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
+}
+
+// Verifies that the At-Risk display is cleared when the turn ends
+void test_EndOfTurnPhase_DisplayClearsAtRisk() {
+    Game game;
+    setupGameWithPlayers(game, 4);
+    game.currentPhase = game.getPhase<EndOfTurnPhase>();
+
+    Displays displays(game.scoreDisplay, game.grid, game.farkleLights, game.textDisplay);
+    game.currentPhase->display(game.state, displays);
+
+    // ScoreDisplay mock captures the state of clearing the displays
+    TEST_ASSERT_TRUE(game.scoreDisplay.cleared_displays[ScoreDisplay::DisplayType::AT_RISK_SCORE]);
+}
+
+// Verifies that the phase properly waits when no input is provided
+void test_EndOfTurnPhase_WaitWithoutInput() {
+    Game game;
+    setupGameWithPlayers(game, 4);
+    game.state.atRiskScore = 0;
+    game.currentPhase = game.getPhase<EndOfTurnPhase>();
+    game.currentPhase->onEnter(game.state);
+
+    for (int i = 0; i < 50; i++) {
+        simulateNoAction(game);
+    }
+
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<EndOfTurnPhase>(), game.currentPhase);
+}
+
+void run_end_of_turn_phase_tests() {
+    RUN_TEST(test_EndOfTurnPhase_ManualAdvance);
+    RUN_TEST(test_EndOfTurnPhase_FinalRoundTrigger);
+    RUN_TEST(test_EndOfTurnPhase_DisplayClearsAtRisk);
+    RUN_TEST(test_EndOfTurnPhase_WaitWithoutInput);
+}

--- a/src/farkle/test/test_game_logic/small_tests/test_EndOfTurnPhase.h
+++ b/src/farkle/test/test_game_logic/small_tests/test_EndOfTurnPhase.h
@@ -1,0 +1,6 @@
+#ifndef TEST_ENDOFTURNPHASE_H
+#define TEST_ENDOFTURNPHASE_H
+
+void run_end_of_turn_phase_tests();
+
+#endif

--- a/src/farkle/test/test_game_logic/small_tests/test_FarklingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_FarklingPhase.cpp
@@ -77,8 +77,8 @@ void test_FarklingPhase_IncrementWithPoints() {
     TEST_ASSERT_EQUAL_INT(1, game.state.players[0].farkle_count);
 }
 
-// Verifies that a button press transitions to the WaitingPhase after the animation is complete.
-void test_FarklingPhase_ManualAdvance() {
+// Verifies that when atRiskScore reaches 0, it transitions to EndOfTurnPhase.
+void test_FarklingPhase_TransitionsToEndOfTurn() {
     Game game;
     setupGameWithPlayers(game, 4);
     game.state.atRiskScore = 0;
@@ -87,11 +87,9 @@ void test_FarklingPhase_ManualAdvance() {
     game.state.currentPlayerIndex = 0;
 
     simulateNoAction(game);
-    TEST_ASSERT_EQUAL_PTR(game.getPhase<FarklingPhase>(), game.currentPhase);
 
-    simulateButtonPress(game, ButtonAction::CLEAR);
-
-    TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
+    // As soon as atRiskScore is 0 and it updates, it transitions to EndOfTurnPhase
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<EndOfTurnPhase>(), game.currentPhase);
 }
 
 // Verifies that the Competition Score display blinks during the final round in FarklingPhase.
@@ -128,7 +126,7 @@ void run_farkling_phase_tests() {
     RUN_TEST(test_FarklingPhase_AnimationMath);
     RUN_TEST(test_FarklingPhase_ZeroFloorSafety);
     RUN_TEST(test_FarklingPhase_InputSpamming);
-    RUN_TEST(test_FarklingPhase_ManualAdvance);
+    RUN_TEST(test_FarklingPhase_TransitionsToEndOfTurn);
     RUN_TEST(test_FarklingPhase_NoHarmNoFoul_NoIncrement);
     RUN_TEST(test_FarklingPhase_IncrementWithPoints);
     RUN_TEST(test_FarklingPhase_FinalRoundBlinking);

--- a/src/farkle/test/test_game_logic/small_tests/test_PenaltyFarklingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PenaltyFarklingPhase.cpp
@@ -85,8 +85,8 @@ void test_PenaltyFarklingPhase_InputSpamming() {
     TEST_ASSERT_EQUAL_PTR(game.getPhase<PenaltyFarklingPhase>(), game.currentPhase);
 }
 
-// Verifies that a button press transitions to the WaitingPhase after the animation is complete.
-void test_PenaltyFarklingPhase_ManualAdvance() {
+// Verifies that after THE_DRAIN completes, it transitions to the EndOfTurnPhase.
+void test_PenaltyFarklingPhase_TransitionsToEndOfTurn() {
     Game game;
     setupGameWithPlayers(game, 4);
     game.currentPhase = game.getPhase<PenaltyFarklingPhase>();
@@ -97,13 +97,12 @@ void test_PenaltyFarklingPhase_ManualAdvance() {
     simulateNoAction(game, 5010);
     // Advance past THE_DRAIN (100ms)
     simulateNoAction(game, 500);
+    // 1 more tick to let the next cycle return the phase transition
+    simulateNoAction(game, 10);
 
+    // It should now transition to EndOfTurnPhase
     TEST_ASSERT_EQUAL_INT(0, game.state.atRiskScore);
-    TEST_ASSERT_EQUAL_PTR(game.getPhase<PenaltyFarklingPhase>(), game.currentPhase);
-
-    simulateButtonPress(game, ButtonAction::CLEAR);
-
-    TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<EndOfTurnPhase>(), game.currentPhase);
 }
 
 // Verifies that the Competition Score display blinks during the final round in PenaltyFarklingPhase.
@@ -141,7 +140,7 @@ void run_penalty_farkling_phase_tests() {
     RUN_TEST(test_PenaltyFarklingPhase_BlinkParameter);
     RUN_TEST(test_PenaltyFarklingPhase_ZeroCeilingSafety);
     RUN_TEST(test_PenaltyFarklingPhase_InputSpamming);
-    RUN_TEST(test_PenaltyFarklingPhase_ManualAdvance);
+    RUN_TEST(test_PenaltyFarklingPhase_TransitionsToEndOfTurn);
     RUN_TEST(test_PenaltyFarklingPhase_FinalRoundBlinking);
     RUN_TEST(test_PenaltyFarklingPhase_GridAnimationScores);
 }

--- a/src/farkle/test/test_game_logic/test_main.cpp
+++ b/src/farkle/test/test_game_logic/test_main.cpp
@@ -5,6 +5,7 @@
 #include "small_tests/test_FarklingPhase.h"
 #include "small_tests/test_PenaltyFarklingPhase.h"
 #include "small_tests/test_BankingPhase.h"
+#include "small_tests/test_EndOfTurnPhase.h"
 #include "large_tests/test_full_game.h"
 #include "medium_tests/test_turn_lifecycle.h"
 #include "medium_tests/test_conditional_at_risk_display.h"
@@ -26,6 +27,7 @@ void test_runner() {
     run_farkling_phase_tests();
     run_penalty_farkling_phase_tests();
     run_banking_phase_tests();
+    run_end_of_turn_phase_tests();
     run_full_game_tests();
     run_turn_lifecycle_tests();
     run_display_logic_tests();


### PR DESCRIPTION
Introduces a new `EndOfTurnPhase` state to abstract and centralize the "waiting for user dismissal" logic that occurs after scoring animations. Instead of duplicating the `input.action != NONE` wait, final round trigger check, and `endTurn()` call across `BankingPhase`, `FarklingPhase`, and `PenaltyFarklingPhase`, these phases now simply transition to `EndOfTurnPhase` when they reach `atRiskScore == 0`. Also updates all corresponding tests and design documentation.

---
*PR created automatically by Jules for task [4225334276948002234](https://jules.google.com/task/4225334276948002234) started by @gwenrich136*