### PR TITLE
✨ Introduce Head-to-Head display in WaitingPhase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ When writing code:
 *   **Logic:** Resides strictly in `GamePhase` classes.
 *   **Context:** The `Game` class is a minimal Context that owns data (`GameState`) and hardware.
 *   **Memory Rule:** Strictly **NO Dynamic Allocation** (`new`, `malloc`) for phases or core logic. Use the `PhasePool` via `game.getPhase<T>()`.
+    *   **Guidance on Large Objects:** Do not dynamically allocate large objects like `GameState`.
+    *   **String/State Caching:** Avoid copying large strings (like C-style `strncpy` arrays) in UI component state caches. Instead, reference pointers to `std::string` objects already defined in long-lived state (e.g., `Player` objects) whenever possible.
 *   **Hardware Ownership:** The `Game` class owns the hardware. Phases only *borrow* it. Only `Game::setup()` initializes hardware.
 
 ### Commenting Style

--- a/design/COMPONENT_LIBRARIES.md
+++ b/design/COMPONENT_LIBRARIES.md
@@ -187,6 +187,7 @@ The `TextDisplayV2` component is a high-performance UI manager for the **ST7789 
 
 #### Interactive UI Modes
 -   **`void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue = 0xFFFF)`**: Renders an interactive selection screen. The `selectionItem` can be rendered in a specific `hue` (defaulting to White) to highlight player identities during setup.
+-   **`void printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue)`**: Renders a split-screen "Leaderboard" or "Head-to-Head" display used during in-game phases. Displays the current player (P1) on the top half and the competitor/leader (P2) on the bottom half, including rank ordinal strings (e.g., "1st", "2nd") aligned to the left edge of the player names.
 -   **`void displayCharacterInput(const char* currentName, int activeIndex, uint16_t hue = 0xFFFF)`**: Renders an interactive screen for name input, with the active character highlighted in the provided `hue`.
 
 ### Key Logic & Behavior

--- a/design/IN_GAME_PHASES.md
+++ b/design/IN_GAME_PHASES.md
@@ -75,6 +75,7 @@ This category handles user input for scoring, provides feedback through animatio
 
 ### Visual Feedback
 -   **Unified Color Identity:** The `TextDisplayV2` renders the active player's name and critical turn information in the `Player.color` stored in the `GameState`. This matches the player's row on the `LedProgressGrid`, creating a cohesive visual link between the scoreboard and the high-resolution UI.
+-   **Head-to-Head Display:** During all `InGamePhase` subclasses, the `TextDisplayV2` shows a split-screen "Leaderboard" view. The top half displays the current player's name and rank (e.g., "1st", "2nd"), colored in their hue. The bottom half displays the current game leader's name and rank, wrapped in selection arrows to indicate that the user can theoretically scroll through the competition. Both players' ranks are aligned to the left edge of their respective names.
 -   **Turn Indicator (FarkleWarningLights):**
     -   **WaitingPhase:** The current player's LED blinks (White/Yellow/Red) to indicate it is their turn to act.
     -   **Banking/Farkling Phases:** The current player's LED becomes solid (like other players) during animations, reducing visual noise.

--- a/src/farkle/include/GamePhase.h
+++ b/src/farkle/include/GamePhase.h
@@ -70,6 +70,11 @@ protected:
     // Helper to calculate the highest score among all players
     int calculateLeadingScore(const GameState& state);
 
+    // Head-to-head text display helpers
+    int getLeaderIndex(const GameState& state);
+    int getPlayerRank(const GameState& state, int playerIndex);
+    void getOrdinalString(int rank, char* buffer, size_t bufferSize);
+
     // Helper to advance to the next player
     void endTurn(GameState& state);
 

--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
@@ -1,5 +1,7 @@
 #include "TextDisplayV2.h"
 #include <Fonts/FreeSans18pt7b.h>
+#include <Fonts/FreeSans12pt7b.h>
+#include <Fonts/FreeSans9pt7b.h>
 #include <math.h>
 #include <cstring>
 
@@ -14,6 +16,12 @@ TextDisplayV2::TextDisplayV2(int cs, int dc, int res, int blk)
     _lastMessage[0] = '\0';
     _lastTitle[0] = '\0';
     _lastItem[0] = '\0';
+    _lastP1Place[0] = '\0';
+    _lastP1Name[0] = '\0';
+    _lastP1Hue = 0xFFFF;
+    _lastP2Place[0] = '\0';
+    _lastP2Name[0] = '\0';
+    _lastP2Hue = 0xFFFF;
 }
 
 void TextDisplayV2::begin() {
@@ -107,6 +115,61 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
     }
 }
 
+void TextDisplayV2::printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue)
+{
+    if (_currentMode == DisplayModeV2::HEAD_TO_HEAD &&
+        strcmp(_lastP1Place, p1Place) == 0 &&
+        strcmp(_lastP1Name, p1Name) == 0 &&
+        _lastP1Hue == p1Hue &&
+        strcmp(_lastP2Place, p2Place) == 0 &&
+        strcmp(_lastP2Name, p2Name) == 0 &&
+        _lastP2Hue == p2Hue) {
+        return;
+    }
+
+    bool p1Changed = (strcmp(_lastP1Place, p1Place) != 0) || (strcmp(_lastP1Name, p1Name) != 0) || (_lastP1Hue != p1Hue);
+    bool p2Changed = (strcmp(_lastP2Place, p2Place) != 0) || (strcmp(_lastP2Name, p2Name) != 0) || (_lastP2Hue != p2Hue);
+    bool modeChanged = _currentMode != DisplayModeV2::HEAD_TO_HEAD;
+
+    if (modeChanged) {
+        _display.fillScreen(ST77XX_BLACK);
+    } else {
+        if (p1Changed) {
+            eraseAlignedPlaceAndNameBoundingBox(_lastP1Place, _lastP1Name, &FreeSans18pt7b, &FreeSans12pt7b, LCD_HEIGHT / 4);
+        }
+        if (p2Changed) {
+            eraseAlignedPlaceAndNameBoundingBox(_lastP2Place, _lastP2Name, &FreeSans12pt7b, &FreeSans9pt7b, (LCD_HEIGHT / 4) * 3);
+            // Re-draw arrows when p2 changes because its bounding box erase might clip them
+            // Or we just rely on drawSelectionArrows redrawing cleanly. Let's let the helper redraw it below.
+        }
+    }
+
+    _currentMode = DisplayModeV2::HEAD_TO_HEAD;
+    strncpy(_lastP1Place, p1Place, sizeof(_lastP1Place) - 1); _lastP1Place[sizeof(_lastP1Place) - 1] = '\0';
+    strncpy(_lastP1Name, p1Name, sizeof(_lastP1Name) - 1); _lastP1Name[sizeof(_lastP1Name) - 1] = '\0';
+    _lastP1Hue = p1Hue;
+    strncpy(_lastP2Place, p2Place, sizeof(_lastP2Place) - 1); _lastP2Place[sizeof(_lastP2Place) - 1] = '\0';
+    strncpy(_lastP2Name, p2Name, sizeof(_lastP2Name) - 1); _lastP2Name[sizeof(_lastP2Name) - 1] = '\0';
+    _lastP2Hue = p2Hue;
+
+    uint16_t c1 = (p1Hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(p1Hue);
+    uint16_t c2 = (p2Hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(p2Hue);
+
+    int16_t dummyY;
+    uint16_t dummyH;
+
+    if (modeChanged || p1Changed) {
+        drawAlignedPlaceAndName(p1Place, p1Name, c1, &FreeSans18pt7b, &FreeSans12pt7b, LCD_HEIGHT / 4, dummyY, dummyH);
+    }
+
+    if (modeChanged || p2Changed) {
+        int16_t p2Y;
+        uint16_t p2H;
+        drawAlignedPlaceAndName(p2Place, p2Name, c2, &FreeSans12pt7b, &FreeSans9pt7b, (LCD_HEIGHT / 4) * 3, p2Y, p2H);
+        drawSelectionArrows(p2Y, p2H);
+    }
+}
+
 void TextDisplayV2::eraseOldTextBoundingBox(const char* text) {
     int16_t oldX1, oldY1;
     uint16_t oldW, oldH;
@@ -114,6 +177,63 @@ void TextDisplayV2::eraseOldTextBoundingBox(const char* text) {
     int16_t oldX = LCD_CENTER_X - (oldW / 2);
     int16_t oldY = LCD_CENTER_Y + (oldH / 2);
     _display.fillRect(oldX + oldX1, oldY + oldY1, oldW, oldH, ST77XX_BLACK);
+}
+
+void TextDisplayV2::eraseAlignedPlaceAndNameBoundingBox(const char* place, const char* name, const GFXfont* nameFont, const GFXfont* placeFont, int16_t baseCenterY) {
+    int16_t nameX1, nameY1, placeX1, placeY1;
+    uint16_t nameW, nameH, placeW, placeH;
+
+    _display.setFont(nameFont);
+    _display.getTextBounds(name, 0, 0, &nameX1, &nameY1, &nameW, &nameH);
+
+    _display.setFont(placeFont);
+    _display.getTextBounds(place, 0, 0, &placeX1, &placeY1, &placeW, &placeH);
+
+    int16_t nameX = LCD_CENTER_X - (nameW / 2);
+    int16_t nameY = baseCenterY + (nameH / 2); // Baseline for name
+
+    // Erase Name
+    _display.fillRect(nameX + nameX1, nameY + nameY1, nameW, nameH, ST77XX_BLACK);
+
+    int16_t placeX = nameX; // Left aligned with name
+    int16_t placeY = nameY - nameH - 5; // Above the name bounding box
+
+    // Erase Place
+    _display.fillRect(placeX + placeX1, placeY + placeY1, placeW, placeH, ST77XX_BLACK);
+}
+
+void TextDisplayV2::drawAlignedPlaceAndName(const char* place, const char* name, uint16_t color, const GFXfont* nameFont, const GFXfont* placeFont, int16_t baseCenterY, int16_t& outY, uint16_t& outH) {
+    int16_t nameX1, nameY1, placeX1, placeY1;
+    uint16_t nameW, nameH, placeW, placeH;
+
+    _display.setFont(nameFont);
+    _display.getTextBounds(name, 0, 0, &nameX1, &nameY1, &nameW, &nameH);
+
+    _display.setFont(placeFont);
+    _display.getTextBounds(place, 0, 0, &placeX1, &placeY1, &placeW, &placeH);
+
+    int16_t nameX = LCD_CENTER_X - (nameW / 2);
+    int16_t nameY = baseCenterY + (nameH / 2);
+
+    int16_t placeX = nameX; // Left aligned with name
+    int16_t placeY = nameY - nameH - 5; // 5px padding above name
+
+    _display.setTextColor(color);
+
+    // Draw Place
+    _display.setFont(placeFont);
+    _display.setCursor(placeX, placeY);
+    _display.print(place);
+
+    // Draw Name
+    _display.setFont(nameFont);
+    _display.setCursor(nameX, nameY);
+    _display.print(name);
+
+    // For bounding arrows around this block, we treat the block's center/bounds based on the name
+    // since the arrows surround the central element
+    outY = nameY;
+    outH = nameH + placeH + 5; // total block height approximation
 }
 
 void TextDisplayV2::drawSelectionTitle(const char* title) {
@@ -139,7 +259,8 @@ void TextDisplayV2::drawSelectionItem(const char* item, uint16_t color, int16_t&
 }
 
 void TextDisplayV2::drawSelectionArrows(int16_t itemY, uint16_t itemH) {
-    int upArrowY = itemY - itemH - ARROW_SPACING;
+    // Offset slightly higher for the top arrow to cover the place text as well
+    int upArrowY = itemY - itemH - ARROW_SPACING + 5;
     int downArrowY = itemY + ARROW_SPACING;
 
     drawArrow(LCD_CENTER_X, upArrowY, true, ST77XX_WHITE);

--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.cpp
@@ -17,10 +17,10 @@ TextDisplayV2::TextDisplayV2(int cs, int dc, int res, int blk)
     _lastTitle[0] = '\0';
     _lastItem[0] = '\0';
     _lastP1Place[0] = '\0';
-    _lastP1Name[0] = '\0';
+    _lastP1Name = nullptr;
     _lastP1Hue = 0xFFFF;
     _lastP2Place[0] = '\0';
-    _lastP2Name[0] = '\0';
+    _lastP2Name = nullptr;
     _lastP2Hue = 0xFFFF;
 }
 
@@ -115,30 +115,32 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
     }
 }
 
-void TextDisplayV2::printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue)
+void TextDisplayV2::printHeadToHeadScreen(const char* p1Place, const std::string* p1Name, uint16_t p1Hue, const char* p2Place, const std::string* p2Name, uint16_t p2Hue)
 {
+    if (!p1Name || !p2Name) return;
+
     if (_currentMode == DisplayModeV2::HEAD_TO_HEAD &&
         strcmp(_lastP1Place, p1Place) == 0 &&
-        strcmp(_lastP1Name, p1Name) == 0 &&
+        _lastP1Name == p1Name &&
         _lastP1Hue == p1Hue &&
         strcmp(_lastP2Place, p2Place) == 0 &&
-        strcmp(_lastP2Name, p2Name) == 0 &&
+        _lastP2Name == p2Name &&
         _lastP2Hue == p2Hue) {
         return;
     }
 
-    bool p1Changed = (strcmp(_lastP1Place, p1Place) != 0) || (strcmp(_lastP1Name, p1Name) != 0) || (_lastP1Hue != p1Hue);
-    bool p2Changed = (strcmp(_lastP2Place, p2Place) != 0) || (strcmp(_lastP2Name, p2Name) != 0) || (_lastP2Hue != p2Hue);
+    bool p1Changed = (strcmp(_lastP1Place, p1Place) != 0) || (_lastP1Name != p1Name) || (_lastP1Hue != p1Hue);
+    bool p2Changed = (strcmp(_lastP2Place, p2Place) != 0) || (_lastP2Name != p2Name) || (_lastP2Hue != p2Hue);
     bool modeChanged = _currentMode != DisplayModeV2::HEAD_TO_HEAD;
 
     if (modeChanged) {
         _display.fillScreen(ST77XX_BLACK);
     } else {
-        if (p1Changed) {
-            eraseAlignedPlaceAndNameBoundingBox(_lastP1Place, _lastP1Name, &FreeSans18pt7b, &FreeSans12pt7b, LCD_HEIGHT / 4);
+        if (p1Changed && _lastP1Name != nullptr) {
+            eraseAlignedPlaceAndNameBoundingBox(_lastP1Place, _lastP1Name->c_str(), &FreeSans18pt7b, &FreeSans12pt7b, LCD_HEIGHT / 4);
         }
-        if (p2Changed) {
-            eraseAlignedPlaceAndNameBoundingBox(_lastP2Place, _lastP2Name, &FreeSans12pt7b, &FreeSans9pt7b, (LCD_HEIGHT / 4) * 3);
+        if (p2Changed && _lastP2Name != nullptr) {
+            eraseAlignedPlaceAndNameBoundingBox(_lastP2Place, _lastP2Name->c_str(), &FreeSans12pt7b, &FreeSans9pt7b, (LCD_HEIGHT / 4) * 3);
             // Re-draw arrows when p2 changes because its bounding box erase might clip them
             // Or we just rely on drawSelectionArrows redrawing cleanly. Let's let the helper redraw it below.
         }
@@ -146,10 +148,10 @@ void TextDisplayV2::printHeadToHeadScreen(const char* p1Place, const char* p1Nam
 
     _currentMode = DisplayModeV2::HEAD_TO_HEAD;
     strncpy(_lastP1Place, p1Place, sizeof(_lastP1Place) - 1); _lastP1Place[sizeof(_lastP1Place) - 1] = '\0';
-    strncpy(_lastP1Name, p1Name, sizeof(_lastP1Name) - 1); _lastP1Name[sizeof(_lastP1Name) - 1] = '\0';
+    _lastP1Name = p1Name;
     _lastP1Hue = p1Hue;
     strncpy(_lastP2Place, p2Place, sizeof(_lastP2Place) - 1); _lastP2Place[sizeof(_lastP2Place) - 1] = '\0';
-    strncpy(_lastP2Name, p2Name, sizeof(_lastP2Name) - 1); _lastP2Name[sizeof(_lastP2Name) - 1] = '\0';
+    _lastP2Name = p2Name;
     _lastP2Hue = p2Hue;
 
     uint16_t c1 = (p1Hue == 0xFFFF) ? ST77XX_WHITE : colorHSVtoRGB565(p1Hue);
@@ -159,13 +161,13 @@ void TextDisplayV2::printHeadToHeadScreen(const char* p1Place, const char* p1Nam
     uint16_t dummyH;
 
     if (modeChanged || p1Changed) {
-        drawAlignedPlaceAndName(p1Place, p1Name, c1, &FreeSans18pt7b, &FreeSans12pt7b, LCD_HEIGHT / 4, dummyY, dummyH);
+        drawAlignedPlaceAndName(p1Place, p1Name->c_str(), c1, &FreeSans18pt7b, &FreeSans12pt7b, LCD_HEIGHT / 4, dummyY, dummyH);
     }
 
     if (modeChanged || p2Changed) {
         int16_t p2Y;
         uint16_t p2H;
-        drawAlignedPlaceAndName(p2Place, p2Name, c2, &FreeSans12pt7b, &FreeSans9pt7b, (LCD_HEIGHT / 4) * 3, p2Y, p2H);
+        drawAlignedPlaceAndName(p2Place, p2Name->c_str(), c2, &FreeSans12pt7b, &FreeSans9pt7b, (LCD_HEIGHT / 4) * 3, p2Y, p2H);
         drawSelectionArrows(p2Y, p2H);
     }
 }

--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.h
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.h
@@ -29,7 +29,7 @@ class TextDisplayV2
     void begin();
     void print(const char* message, uint16_t hue = 0xFFFF);
     void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue = 0xFFFF);
-    void printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue);
+    void printHeadToHeadScreen(const char* p1Place, const std::string* p1Name, uint16_t p1Hue, const char* p2Place, const std::string* p2Name, uint16_t p2Hue);
 
     // Color conversion utility
     static uint16_t colorHSVtoRGB565(uint16_t hue);
@@ -47,10 +47,10 @@ class TextDisplayV2
 
     // Head-to-Head state tracking
     char _lastP1Place[16];
-    char _lastP1Name[32];
+    const std::string* _lastP1Name;
     uint16_t _lastP1Hue;
     char _lastP2Place[16];
-    char _lastP2Name[32];
+    const std::string* _lastP2Name;
     uint16_t _lastP2Hue;
 
     void eraseOldTextBoundingBox(const char* text);

--- a/src/farkle/lib/components/TextDisplay/TextDisplayV2.h
+++ b/src/farkle/lib/components/TextDisplay/TextDisplayV2.h
@@ -18,7 +18,8 @@
 enum class DisplayModeV2 {
     NONE,
     MESSAGE,
-    SELECTION
+    SELECTION,
+    HEAD_TO_HEAD
 };
 
 class TextDisplayV2
@@ -28,6 +29,7 @@ class TextDisplayV2
     void begin();
     void print(const char* message, uint16_t hue = 0xFFFF);
     void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue = 0xFFFF);
+    void printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue);
 
     // Color conversion utility
     static uint16_t colorHSVtoRGB565(uint16_t hue);
@@ -43,7 +45,17 @@ class TextDisplayV2
     char _lastItem[32];
     uint16_t _lastHue;
 
+    // Head-to-Head state tracking
+    char _lastP1Place[16];
+    char _lastP1Name[32];
+    uint16_t _lastP1Hue;
+    char _lastP2Place[16];
+    char _lastP2Name[32];
+    uint16_t _lastP2Hue;
+
     void eraseOldTextBoundingBox(const char* text);
+    void eraseAlignedPlaceAndNameBoundingBox(const char* place, const char* name, const GFXfont* nameFont, const GFXfont* placeFont, int16_t baseCenterY);
+    void drawAlignedPlaceAndName(const char* place, const char* name, uint16_t color, const GFXfont* nameFont, const GFXfont* placeFont, int16_t baseCenterY, int16_t& outY, uint16_t& outH);
     void drawSelectionTitle(const char* title);
     void drawSelectionItem(const char* item, uint16_t color, int16_t& itemY, uint16_t& itemH);
     void drawSelectionArrows(int16_t itemY, uint16_t itemH);

--- a/src/farkle/src/phases/InGamePhase.cpp
+++ b/src/farkle/src/phases/InGamePhase.cpp
@@ -90,10 +90,10 @@ void InGamePhase::updateTextDisplay(const GameState& state, const Displays& disp
 
     displays.textDisplay.printHeadToHeadScreen(
         p1Place,
-        state.players[currentPlayerIdx].name.c_str(),
+        &state.players[currentPlayerIdx].name,
         state.players[currentPlayerIdx].hue,
         p2Place,
-        state.players[leaderIdx].name.c_str(),
+        &state.players[leaderIdx].name,
         state.players[leaderIdx].hue
     );
 }

--- a/src/farkle/src/phases/InGamePhase.cpp
+++ b/src/farkle/src/phases/InGamePhase.cpp
@@ -72,8 +72,73 @@ void InGamePhase::updateWarningLights(const GameState& state, const Displays& di
 }
 
 void InGamePhase::updateTextDisplay(const GameState& state, const Displays& displays) {
-    // Basic turn indicator for now
-    displays.textDisplay.print(state.players[state.currentPlayerIndex].name.c_str(), state.players[state.currentPlayerIndex].hue);
+    if (state.players.empty()) return;
+
+    int currentPlayerIdx = state.currentPlayerIndex;
+    int leaderIdx = getLeaderIndex(state);
+
+    // Fallback if leader is not found (shouldn't happen if players is not empty)
+    if (leaderIdx == -1) leaderIdx = currentPlayerIdx;
+
+    int p1Rank = getPlayerRank(state, currentPlayerIdx);
+    int p2Rank = getPlayerRank(state, leaderIdx);
+
+    char p1Place[16];
+    char p2Place[16];
+    getOrdinalString(p1Rank, p1Place, sizeof(p1Place));
+    getOrdinalString(p2Rank, p2Place, sizeof(p2Place));
+
+    displays.textDisplay.printHeadToHeadScreen(
+        p1Place,
+        state.players[currentPlayerIdx].name.c_str(),
+        state.players[currentPlayerIdx].hue,
+        p2Place,
+        state.players[leaderIdx].name.c_str(),
+        state.players[leaderIdx].hue
+    );
+}
+
+int InGamePhase::getLeaderIndex(const GameState& state) {
+    int maxScore = -1;
+    int leaderIdx = -1;
+    for (size_t i = 0; i < state.players.size(); ++i) {
+        if (state.players[i].score > maxScore) {
+            maxScore = state.players[i].score;
+            leaderIdx = (int)i;
+        }
+    }
+    return leaderIdx;
+}
+
+int InGamePhase::getPlayerRank(const GameState& state, int playerIndex) {
+    if (playerIndex < 0 || playerIndex >= (int)state.players.size()) return 1;
+
+    int rank = 1;
+    int targetScore = state.players[playerIndex].score;
+
+    for (size_t i = 0; i < state.players.size(); ++i) {
+        // If someone has a strictly higher score, they push this player down in rank
+        if (state.players[i].score > targetScore) {
+            rank++;
+        }
+    }
+    return rank;
+}
+
+void InGamePhase::getOrdinalString(int rank, char* buffer, size_t bufferSize) {
+    if (bufferSize < 5) return; // need at least "Nth\0"
+
+    const char* suffix = "th";
+    int lastDigit = rank % 10;
+    int lastTwoDigits = rank % 100;
+
+    if (lastTwoDigits < 11 || lastTwoDigits > 13) {
+        if (lastDigit == 1) suffix = "st";
+        else if (lastDigit == 2) suffix = "nd";
+        else if (lastDigit == 3) suffix = "rd";
+    }
+
+    snprintf(buffer, bufferSize, "%d%s", rank, suffix);
 }
 
 int InGamePhase::calculateLeadingScore(const GameState& state) {

--- a/src/farkle/test/mocks/include/TextDisplayV2.h
+++ b/src/farkle/test/mocks/include/TextDisplayV2.h
@@ -22,7 +22,7 @@ public:
     void begin();
     void print(const char* message, uint16_t hue = 0xFFFF);
     void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue = 0xFFFF);
-    void printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue);
+    void printHeadToHeadScreen(const char* p1Place, const std::string* p1Name, uint16_t p1Hue, const char* p2Place, const std::string* p2Name, uint16_t p2Hue);
 };
 
 #endif // MOCK_TEXT_DISPLAY_V2_H

--- a/src/farkle/test/mocks/include/TextDisplayV2.h
+++ b/src/farkle/test/mocks/include/TextDisplayV2.h
@@ -11,10 +11,18 @@ public:
     std::string captured_item;
     uint16_t captured_hue;
 
+    std::string captured_p1Place;
+    std::string captured_p1Name;
+    uint16_t captured_p1Hue;
+    std::string captured_p2Place;
+    std::string captured_p2Name;
+    uint16_t captured_p2Hue;
+
     TextDisplayV2(int cs, int dc, int res, int blk);
     void begin();
     void print(const char* message, uint16_t hue = 0xFFFF);
     void printSelectionScreen(const char* selectionTitle, const char* selectionItem, uint16_t hue = 0xFFFF);
+    void printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue);
 };
 
 #endif // MOCK_TEXT_DISPLAY_V2_H

--- a/src/farkle/test/mocks/libs/Adafruit_GFX.h
+++ b/src/farkle/test/mocks/libs/Adafruit_GFX.h
@@ -24,6 +24,7 @@ typedef struct {
 } GFXfont;
 
 extern const GFXfont FreeSans9pt7b;
+extern const GFXfont FreeSans12pt7b;
 extern const GFXfont FreeSans18pt7b;
 
 struct MockAdafruitPrintCall {

--- a/src/farkle/test/mocks/libs/Fonts/FreeSans12pt7b.h
+++ b/src/farkle/test/mocks/libs/Fonts/FreeSans12pt7b.h
@@ -1,0 +1,7 @@
+#ifndef _FREESANS12PT7B_H
+#define _FREESANS12PT7B_H
+
+#include "../Adafruit_GFX.h"
+
+// Font included from Adafruit_GFX.cpp mock
+#endif

--- a/src/farkle/test/mocks/src/Adafruit_GFX.cpp
+++ b/src/farkle/test/mocks/src/Adafruit_GFX.cpp
@@ -9,4 +9,5 @@ int mockAdafruitFillScreenCount = 0;
 
 // Dummy Font definition
 const GFXfont FreeSans9pt7b = {nullptr, nullptr, 0x20, 0x7E, 22};
+const GFXfont FreeSans12pt7b = {nullptr, nullptr, 0x20, 0x7E, 28};
 const GFXfont FreeSans18pt7b = {nullptr, nullptr, 0x20, 0x7E, 44};

--- a/src/farkle/test/mocks/src/TextDisplayV2.cpp
+++ b/src/farkle/test/mocks/src/TextDisplayV2.cpp
@@ -19,11 +19,11 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
     captured_hue = hue;
 }
 
-void TextDisplayV2::printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue) {
+void TextDisplayV2::printHeadToHeadScreen(const char* p1Place, const std::string* p1Name, uint16_t p1Hue, const char* p2Place, const std::string* p2Name, uint16_t p2Hue) {
+    if (p1Name) captured_p1Name = *p1Name;
+    if (p2Name) captured_p2Name = *p2Name;
     captured_p1Place = p1Place;
-    captured_p1Name = p1Name;
     captured_p1Hue = p1Hue;
     captured_p2Place = p2Place;
-    captured_p2Name = p2Name;
     captured_p2Hue = p2Hue;
 }

--- a/src/farkle/test/mocks/src/TextDisplayV2.cpp
+++ b/src/farkle/test/mocks/src/TextDisplayV2.cpp
@@ -18,3 +18,12 @@ void TextDisplayV2::printSelectionScreen(const char* selectionTitle, const char*
     captured_item = selectionItem;
     captured_hue = hue;
 }
+
+void TextDisplayV2::printHeadToHeadScreen(const char* p1Place, const char* p1Name, uint16_t p1Hue, const char* p2Place, const char* p2Name, uint16_t p2Hue) {
+    captured_p1Place = p1Place;
+    captured_p1Name = p1Name;
+    captured_p1Hue = p1Hue;
+    captured_p2Place = p2Place;
+    captured_p2Name = p2Name;
+    captured_p2Hue = p2Hue;
+}

--- a/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
@@ -52,7 +52,8 @@ void test_TurnLifecycle_FullSetupAndTurn() {
     simulateButtonPress(game, ButtonAction::FARKLE);
 
     // Should be in WaitingPhase, showing first player (Coach)
-    TEST_ASSERT_EQUAL_STRING("Coach", game.textDisplay.captured_message.c_str());
+    TEST_ASSERT_EQUAL_STRING("Coach", game.textDisplay.captured_p1Name.c_str());
+    TEST_ASSERT_EQUAL_STRING("1st", game.textDisplay.captured_p1Place.c_str());
     TEST_ASSERT_EQUAL_INT(0, game.state.currentPlayerIndex);
 }
 

--- a/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
@@ -101,8 +101,9 @@ void test_PlayerSelection_TransitionValidation() {
     // Now can start
     simulateButtonPress(game, ButtonAction::FARKLE);
 
-    // Should be in WaitingPhase (OLED shows player name)
-    TEST_ASSERT_EQUAL_STRING("Geewee", game.textDisplay.captured_message.c_str());
+    // Should be in WaitingPhase (OLED shows Head-to-Head info now instead of basic message)
+    TEST_ASSERT_EQUAL_STRING("Geewee", game.textDisplay.captured_p1Name.c_str());
+    TEST_ASSERT_EQUAL_STRING("1st", game.textDisplay.captured_p1Place.c_str());
 }
 
 // Verifies that the phase respects the 8-player hardware limit and shows "ROSTER FULL" using a simple print.


### PR DESCRIPTION
Implements the first step of the Leaderboard Display feature. During the WaitingPhase (and other in-game phases), the TextDisplayV2 now shows a split-screen layout. The current player's place and name are prominent on the top half, while the current game leader's place and name are shown on the bottom half, wrapped in selection arrows.

All component tests and game logic tests are passing.

---
*PR created automatically by Jules for task [2191628150826772424](https://jules.google.com/task/2191628150826772424) started by @gwenrich136*