### PR TITLE
feat: Add 5-second automatic timeout to EndOfTurnPhase

### DIFF
--- a/design/GENERAL_GAME_PLAY.md
+++ b/design/GENERAL_GAME_PLAY.md
@@ -60,16 +60,16 @@ The game begins by guiding players through setup and configuration.
     - The player's consecutive farkle count is also reset to zero at the beginning of this phase, causing the `FarkleWarningLights` to turn off immediately.
     -   **Note on Visuals:** The `LedProgressGrid` uses a logarithmic/exponential brightness curve for the "remainder" pixel. This ensures that the visual progression appears smooth and linear to the human eye, avoiding sudden jumps in brightness during these animations.
     -   Input is locked during this animation.
-    -   **Manual Advance:** Once the animation completes (at-risk score is 0), the game persists in its final state, showing the updated score. The game waits indefinitely until **any button** is pressed on the `ControlPad`.
-    -   **Transition:** Upon button press, the game advances to the next player's turn and returns to the `WaitingPhase`.
+    -   **Manual Advance:** Once the animation completes (at-risk score is 0), the game persists in its final state, showing the updated score. The game waits until **any button** is pressed on the `ControlPad`, or automatically advances after 5 seconds of inactivity.
+    -   **Transition:** Upon button press or timeout, the game advances to the next player's turn and returns to the `WaitingPhase`.
 -   **Standard Farkle Animation:**
     -   If a player farkles (but it's not their third consecutive farkle), their `atRisk` score slowly drains to zero.
     -   **No Harm, No Foul Rule:** If the player's Banked Score is 0, their consecutive farkle count does **not** increment. Warning lights do not turn on. You cannot get "strikes" if you have no points to lose.
     -   A witty quip related to farkling is displayed on the `TextDisplay`.
     -   The `FarkleWarningLights` update to reflect the new farkle count (if applicable).
     -   Input is locked during this animation.
-    -   **Manual Advance:** Once the animation completes, the game remains in this state (displaying the quip and updated lights) and waits for **any button** press.
-    -   **Transition:** Upon button press, the game advances to the next player's turn and returns to the `WaitingPhase`.
+    -   **Manual Advance:** Once the animation completes, the game remains in this state (displaying the quip and updated lights) and waits for **any button** press or automatically advances after 5 seconds of inactivity.
+    -   **Transition:** Upon button press or timeout, the game advances to the next player's turn and returns to the `WaitingPhase`.
 
 ### 2.3 Catastrophic Farkle (Third Consecutive Farkle)
 -   **Trigger:** When a player gets their third consecutive farkle in a turn (and has points to lose).
@@ -87,7 +87,7 @@ The game begins by guiding players through setup and configuration.
         *   The `FarkleWarningLights` **continue alternating** throughout this drain.
     3.  **The Aftermath:**
         *   Once the scores settle, the `FarkleWarningLights` turn **OFF**.
-        *   The game waits for a button press to advance.
+        *   The game waits for a button press or automatically advances after 5 seconds of inactivity.
     -   **Reset Logic:** The player's consecutive farkle count is internally reset to 0 immediately upon entering this phase, consistent with other phases. The lights alternate purely due to the phase state.
 
 ---

--- a/design/IN_GAME_PHASES.md
+++ b/design/IN_GAME_PHASES.md
@@ -15,7 +15,7 @@ This category handles user input for scoring, provides feedback through animatio
 - `WaitingPhase` -> `FarklingPhase` (on Farkle button)
 - `WaitingPhase` -> `PenaltyFarklingPhase` (on 3rd consecutive Farkle)
 - All animation phases (`BankingPhase`, `FarklingPhase`, `PenaltyFarklingPhase`) return to `EndOfTurnPhase` after animation completion.
-- `EndOfTurnPhase` returns to `WaitingPhase` after a button press.
+- `EndOfTurnPhase` returns to `WaitingPhase` after a button press or after 5 seconds of inactivity.
 - `WaitingPhase` transitions to `PostGamePhase_V1` when a player reaches the target score and the final round completes.
 
 ## 4. Technical Details
@@ -63,8 +63,8 @@ This category handles user input for scoring, provides feedback through animatio
 *   **Why:** Implements a single unified state to wait for turn dismissal across all in-game scoring outcomes.
 *   **Defined in:** `src/farkle/include/phases/EndOfTurnPhase.h` & `src/farkle/src/phases/EndOfTurnPhase.cpp`
 *   **Implementation Details:**
-    1.  **Wait for Dismissal:** The `update()` method waits for any button press (`input.action != NONE`).
-    2.  **Finalize Turn:** Once a button is pressed:
+    1.  **Wait for Dismissal:** The `update()` method waits for any button press (`input.action != NONE`) or for a 5-second timeout (`m_elapsedTime >= 5000`).
+    2.  **Finalize Turn:** Once a button is pressed or the 5-second timeout occurs:
         a. Check if `!state.finalRoundTriggered` and if the current player's score is now `>= state.targetScore`. If so, set `state.finalRoundTriggered = true;`.
         b. Call the shared helper `this->endTurn(state);` to advance the `currentPlayerIndex`.
         c. `return game.getPhase<WaitingPhase>();`.

--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -116,6 +116,12 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_PenaltyFarklingPhase_FinalRoundBlinking`:** Verifies that the Competition Score display blinks when `finalRoundTriggered` is true.
     *   **`test_PenaltyFarklingPhase_GridAnimationScores`:** Verifies that the LedProgressGrid receives the correct scores and NO blinking score during the PenaltyFarklingPhase.
 
+*   **`test_EndOfTurnPhase.cpp`**
+    *   **`test_EndOfTurnPhase_ManualAdvance`:** Verifies that a button press advances the turn and transitions to `WaitingPhase`.
+    *   **`test_EndOfTurnPhase_FinalRoundTrigger`:** Verifies that the phase correctly triggers final round if score condition met.
+    *   **`test_EndOfTurnPhase_DisplayClearsAtRisk`:** Verifies that the At-Risk display is cleared when the turn ends.
+    *   **`test_EndOfTurnPhase_WaitWithoutInput`:** Verifies that the phase properly waits and automatically advances after a 5-second timeout.
+
 *   **`test_TargetScoreSelectionPhase.cpp`**
     *   **`test_TargetScoreSelection_InitialState`**: Verifies that the phase starts with the default target score (10,000).
     *   **`test_TargetScoreSelection_Adjustment`**: Verifies that `rotationDelta` (Encoder) increments and decrements the target score correctly.
@@ -166,6 +172,7 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_FullGame_StandardGame`**: Replaces hardcoded initialization. The test now simulates the full user journey: Selecting 2-4 players -> Playing until target score -> Winner celebration -> Reset.
     *   **`test_FullGame_TripleFarkle`:** Verifies the triple farkle penalty and reset behavior.
     *   **`test_FullGame_TripleFarkle_ScoreLessThanPenalty`:** Verifies that player score does not go negative when triple farkled.
+    *   **`test_FullGame_AutoAdvanceTurn`:** Verifies that a full game can be completed solely via the 5-second automatic timeout for turn advancement.
     *   **`test_FullGame_FinalRoundBlinking`**: Verifies that the Competition Score display begins blinking as soon as the final round is triggered and remains blinking until the game ends.
 
 

--- a/src/farkle/include/phases/EndOfTurnPhase.h
+++ b/src/farkle/include/phases/EndOfTurnPhase.h
@@ -12,6 +12,9 @@ public:
 protected:
     virtual void updateAtRiskScoreDisplay(const GameState& state, const Displays& displays) override;
     virtual void updateTextDisplay(const GameState& state, const Displays& displays) override;
+
+private:
+    unsigned long m_elapsedTime = 0;
 };
 
 #endif

--- a/src/farkle/src/phases/EndOfTurnPhase.cpp
+++ b/src/farkle/src/phases/EndOfTurnPhase.cpp
@@ -6,11 +6,15 @@ void EndOfTurnPhase::onEnter(GameState& state) {
     // Phase starts when animation is over.
     // Assert that the animation phase cleaned up the atRiskScore
     assert(state.atRiskScore == 0 && "atRiskScore must be 0 when entering EndOfTurnPhase");
+
+    m_elapsedTime = 0;
 }
 
 GamePhase* EndOfTurnPhase::update(Game& game, GameState& state, GameInput input, unsigned long deltaTime) {
-    // Wait for user dismissal (any button press)
-    if (input.action != ButtonAction::NONE) {
+    m_elapsedTime += deltaTime;
+
+    // Wait for user dismissal (any button press) or timeout
+    if (input.action != ButtonAction::NONE || m_elapsedTime >= 5000) {
         // Check for Final Round Trigger
         if (!state.finalRoundTriggered && state.players[state.currentPlayerIndex].score >= state.targetScore) {
             state.finalRoundTriggered = true;

--- a/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
+++ b/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
@@ -115,6 +115,33 @@ void test_FullGame_TripleFarkle_ScoreLessThanPenalty() {
     TEST_ASSERT_EQUAL_INT(0, game.state.players[0].score);
 }
 
+void test_FullGame_AutoAdvanceTurn() {
+    Game game;
+    setupGameWithPlayers(game, 4);
+
+    int turn = 0;
+    while (game.currentPhase != game.getPhase<PostGamePhase_V1>() && turn < 100) {
+        simulateButtonPress(game, ButtonAction::PLUS_500, 3);
+
+        // Start banking
+        simulateButtonPress(game, ButtonAction::BANK);
+
+        while (game.state.atRiskScore > 0) {
+            simulateNoAction(game);
+        }
+
+        // Instead of pressing a button, wait for 5.1 seconds to auto advance
+        for (int i = 0; i < 51; i++) {
+            simulateNoAction(game, 100);
+        }
+
+        turn++;
+    }
+
+    TEST_ASSERT_LESS_THAN(100, turn); // Game should end in a reasonable number of turns
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<PostGamePhase_V1>(), game.currentPhase);
+}
+
 // Verifies that the Competition Score display begins blinking as soon as the final round is triggered.
 void test_FullGame_FinalRoundBlinking() {
     Game game;
@@ -156,6 +183,7 @@ void run_full_game_tests() {
     RUN_TEST(test_FullGame_StandardGame);
     RUN_TEST(test_FullGame_TripleFarkle);
     RUN_TEST(test_FullGame_TripleFarkle_ScoreLessThanPenalty);
+    RUN_TEST(test_FullGame_AutoAdvanceTurn);
     RUN_TEST(test_FullGame_FinalRoundBlinking);
 }
 

--- a/src/farkle/test/test_game_logic/small_tests/test_EndOfTurnPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_EndOfTurnPhase.cpp
@@ -55,7 +55,7 @@ void test_EndOfTurnPhase_DisplayClearsAtRisk() {
     TEST_ASSERT_TRUE(game.scoreDisplay.cleared_displays[ScoreDisplay::DisplayType::AT_RISK_SCORE]);
 }
 
-// Verifies that the phase properly waits when no input is provided
+// Verifies that the phase properly waits and automatically advances after timeout
 void test_EndOfTurnPhase_WaitWithoutInput() {
     Game game;
     setupGameWithPlayers(game, 4);
@@ -63,11 +63,25 @@ void test_EndOfTurnPhase_WaitWithoutInput() {
     game.currentPhase = game.getPhase<EndOfTurnPhase>();
     game.currentPhase->onEnter(game.state);
 
-    for (int i = 0; i < 50; i++) {
-        simulateNoAction(game);
+    int initialPlayerIndex = game.state.currentPlayerIndex;
+
+    // Simulate 4 seconds (400 calls of simulateNoAction which advances by 10ms each, wait we can just pass time directly)
+    for (int i = 0; i < 40; i++) {
+        simulateNoAction(game, 100);
     }
 
+    // Should still be in EndOfTurnPhase after 4 seconds
     TEST_ASSERT_EQUAL_PTR(game.getPhase<EndOfTurnPhase>(), game.currentPhase);
+    TEST_ASSERT_EQUAL_INT(initialPlayerIndex, game.state.currentPlayerIndex);
+
+    // Simulate 2 more seconds (total 6 seconds)
+    for (int i = 0; i < 20; i++) {
+        simulateNoAction(game, 100);
+    }
+
+    // Should have transitioned to WaitingPhase and advanced player index
+    TEST_ASSERT_EQUAL_PTR(game.getPhase<WaitingPhase>(), game.currentPhase);
+    TEST_ASSERT_NOT_EQUAL(initialPlayerIndex, game.state.currentPlayerIndex);
 }
 
 void run_end_of_turn_phase_tests() {


### PR DESCRIPTION
- Adds a 5-second timeout to the `EndOfTurnPhase` so the game automatically advances turns if the user doesn't dismiss the turn manually.
- Updates game rules and phase design documentation to reflect this update.
- Adds new integration test and updates unit tests to assert the time-based functionality.

---
*PR created automatically by Jules for task [15648458889098720577](https://jules.google.com/task/15648458889098720577) started by @gwenrich136*