### PR TITLE
Update tiebreaker logic to use turnsAwayFromPlayer

### DIFF
--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -139,6 +139,9 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_PlayerSelection_TransitionValidation`**: Verifies that pressing **FARKLE** (Red) is ignored if the player list is empty, but successfully transitions to `WaitingPhase` if at least one player exists.
     *   **`test_PlayerSelection_AddLastPlayerWraps`**: Verifies that adding the last name in the filtered pool correctly wraps the selection index back to the first available name (index 0).
 
+*   **`test_WaitingPhase.cpp`**
+    *   **`test_WaitingPhase_TieBreakerSorting`**: Verifies that players with identical scores are sorted by the tiebreaker (turns away from the current player) when updating the leaderboard list.
+
 *   **`test_multi_press.cpp`** (Test Utilities Verification)
     *   **`test_simulate_button_press_count`**: Verifies that `simulateButtonPress` correctly interprets the optional `count` parameter to trigger multiple button presses in sequence, ensuring the test utility functions as intended.
 
@@ -153,9 +156,9 @@ We will structure our tests into three tiers based on scope and complexity. This
     *   **`test_TurnLifecycle_ClearButton`**: Verifies that the clear button resets the `atRiskScore` to 0.
 
 *   **`test_tie_breaking.cpp`**
-    *   **`test_TieBreaking_Case1`**: Verifies that if multiple players reach the same score (exactly at target), the first one who reached it in the rotation wins.
-    *   **`test_TieBreaking_Case2`**: Verifies that if multiple players reach the same score (above target), the first one who reached it in the rotation wins.
-    *   **`test_TieBreaking_Case3`**: Edge case verifying that "first" is calculated relative to the player who triggered the final round, even if the trigger happens late in the roster.
+    *   **`test_TieBreaking_Case1`**: Verifies that if multiple players reach the same score (exactly at target), the first one who reached it in the rotation wins. Also verifies the in-game ranked list logic during tiebreakers.
+    *   **`test_TieBreaking_Case2`**: Verifies that if multiple players reach the same score (above target), the first one who reached it in the rotation wins. Also verifies the in-game ranked list logic during tiebreakers.
+    *   **`test_TieBreaking_Case3`**: Edge case verifying that "first" is calculated relative to the player who triggered the final round, even if the trigger happens late in the roster. Also verifies the in-game ranked list logic during tiebreakers.
 
 *   **`test_conditional_at_risk_display.cpp`**
     *   **`test_DisplayLogic_PlayerSelection_DisplaysOff`**: Verifies that during the selection phase, `ScoreDisplay` segments and `FarkleWarningLights` are explicitly cleared (except `COMPETITION_SCORE` which shows the target score).

--- a/src/farkle/src/phases/PostGamePhase_V1.cpp
+++ b/src/farkle/src/phases/PostGamePhase_V1.cpp
@@ -2,19 +2,9 @@
 #include "Game.h"
 
 void PostGamePhase_V1::onEnter(GameState& state) {
-    // Determine winner and cache display data
-    // Tie-breaking: first person to reach the high score in the rotation wins.
-    // We start searching from the current player, who is the one who reached the target first.
-    m_highestScore = state.players[state.currentPlayerIndex].score;
-    m_winnerIdx = state.currentPlayerIndex;
-    int numPlayers = (int)state.players.size();
-
-    for (int i = (state.currentPlayerIndex + 1) % numPlayers; i != state.currentPlayerIndex; i = (i + 1) % numPlayers) {
-        if (state.players[i].score > m_highestScore) {
-            m_highestScore = state.players[i].score;
-            m_winnerIdx = i;
-        }
-    }
+    // Winner is already determined by the sorted rankedPlayerIndices list from the start of the turn.
+    m_winnerIdx = state.rankedPlayerIndices[0];
+    m_highestScore = state.players[m_winnerIdx].score;
 
     m_winnerMsg = state.players[m_winnerIdx].name + " WINS!";
 

--- a/src/farkle/src/phases/WaitingPhase.cpp
+++ b/src/farkle/src/phases/WaitingPhase.cpp
@@ -14,9 +14,16 @@ void WaitingPhase::onEnter(GameState& state) {
     }
 
     // Sort the list based on current scores
+    // Secondary tie-breaker: turns away from current player (ascending)
     std::sort(state.rankedPlayerIndices.begin(), state.rankedPlayerIndices.end(),
               [&state](int a, int b) {
-                  return state.players[a].score > state.players[b].score;
+                  if (state.players[a].score != state.players[b].score) {
+                      return state.players[a].score > state.players[b].score;
+                  }
+                  int numPlayers = (int)state.players.size();
+                  int turnsAwayA = (a - state.currentPlayerIndex + numPlayers) % numPlayers;
+                  int turnsAwayB = (b - state.currentPlayerIndex + numPlayers) % numPlayers;
+                  return turnsAwayA < turnsAwayB;
               });
 
     // Set competitor rank to 0, or 1 if 0 is the current player (assuming > 1 player)

--- a/src/farkle/test/test_game_logic/medium_tests/test_tie_breaking.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_tie_breaking.cpp
@@ -45,6 +45,15 @@ void test_TieBreaking_Case1() {
     TEST_ASSERT_EQUAL_INT(3000, game.state.players[2].score);
     TEST_ASSERT_EQUAL_INT(0, game.state.currentPlayerIndex); // Back to Player 1
 
+    // Verify ranked list right before game ends.
+    // Player 1 (index 0): 3000, turnsAway=0
+    // Player 2 (index 1): 0, turnsAway=1
+    // Player 3 (index 2): 3000, turnsAway=2
+    // Rank logic expects: Player 1, Player 3, Player 2
+    TEST_ASSERT_EQUAL_INT(0, game.state.rankedPlayerIndices[0]);
+    TEST_ASSERT_EQUAL_INT(2, game.state.rankedPlayerIndices[1]);
+    TEST_ASSERT_EQUAL_INT(1, game.state.rankedPlayerIndices[2]);
+
     // One more loop to trigger the game end transition in WaitingPhase
     simulateNoAction(game);
 
@@ -85,6 +94,16 @@ void test_TieBreaking_Case2() {
     simulateButtonPress(game, ButtonAction::BANK);
     waitForScoreAnimation(game);
     simulateButtonPress(game, ButtonAction::BANK);
+
+    // Current player is back to P1 (index 0)
+    // P1 (index 0): 3000, turnsAway=0
+    // P2 (index 1): 4000, turnsAway=1
+    // P3 (index 2): 4000, turnsAway=2
+    // Tiebreaker: P2 has turnsAway 1, P3 has turnsAway 2. P2 > P3.
+    // Order: P2, P3, P1
+    TEST_ASSERT_EQUAL_INT(1, game.state.rankedPlayerIndices[0]);
+    TEST_ASSERT_EQUAL_INT(2, game.state.rankedPlayerIndices[1]);
+    TEST_ASSERT_EQUAL_INT(0, game.state.rankedPlayerIndices[2]);
 
     // One more loop to trigger the game end transition in WaitingPhase
     simulateNoAction(game);
@@ -139,6 +158,17 @@ void test_TieBreaking_Case3() {
     simulateButtonPress(game, ButtonAction::BANK);
     waitForScoreAnimation(game);
     simulateButtonPress(game, ButtonAction::BANK);
+
+    // Current player is P2 (index 1) since P1's turn ended.
+    // Scores: P1=3000, P2=3000, P3=3000
+    // Turns away from P2 (index 1):
+    // P2 (idx 1): 0
+    // P3 (idx 2): 1
+    // P1 (idx 0): 2
+    // Order: P2, P3, P1
+    TEST_ASSERT_EQUAL_INT(1, game.state.rankedPlayerIndices[0]);
+    TEST_ASSERT_EQUAL_INT(2, game.state.rankedPlayerIndices[1]);
+    TEST_ASSERT_EQUAL_INT(0, game.state.rankedPlayerIndices[2]);
 
     // One more loop to trigger transition
     simulateNoAction(game);

--- a/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.cpp
@@ -159,7 +159,66 @@ void test_WaitingPhase_GridAnimationScores() {
     TEST_ASSERT_EQUAL_INT(500, game.grid.captured_blinkingScore);
 }
 
+// Verifies tiebreaker sorting when players have the same score
+void test_WaitingPhase_TieBreakerSorting() {
+    Game game;
+    setupGameWithPlayers(game, 4);
+
+    // Give players the same score
+    game.state.players[0].score = 4000;
+    game.state.players[1].score = 4000;
+    game.state.players[2].score = 4000;
+    game.state.players[3].score = 4000;
+
+    // Set current player to P1 (index 1)
+    game.state.currentPlayerIndex = 1;
+    game.currentPhase = game.getPhase<WaitingPhase>();
+    game.currentPhase->onEnter(game.state);
+
+    // Expected ranked list based on turnsAwayFromPlayer (ascending)
+    // P1 (index 1) -> turnsAway = 0
+    // P2 (index 2) -> turnsAway = 1
+    // P3 (index 3) -> turnsAway = 2
+    // P0 (index 0) -> turnsAway = 3
+    TEST_ASSERT_EQUAL_INT(4, game.state.rankedPlayerIndices.size());
+    TEST_ASSERT_EQUAL_INT(1, game.state.rankedPlayerIndices[0]);
+    TEST_ASSERT_EQUAL_INT(2, game.state.rankedPlayerIndices[1]);
+    TEST_ASSERT_EQUAL_INT(3, game.state.rankedPlayerIndices[2]);
+    TEST_ASSERT_EQUAL_INT(0, game.state.rankedPlayerIndices[3]);
+
+    // Now make P3 (index 3) the current player, but P1 and P2 have a different score.
+    // P0: 3000, P1: 4000, P2: 4000, P3: 4000
+    game.state.players[0].score = 3000;
+    game.state.players[1].score = 4000;
+    game.state.players[2].score = 4000;
+    game.state.players[3].score = 4000;
+
+    game.state.currentPlayerIndex = 3;
+    game.currentPhase->onEnter(game.state);
+
+    // Expected ranked list:
+    // P3, P1, P2 all have 4000. P0 has 3000.
+    // P3 turnsAway = 0 -> ranked 0
+    // P1 turnsAway = 2 -> ranked 2 (wait, P0 is index 0. turnsAway(0)=1, turnsAway(1)=2, turnsAway(2)=3)
+    // Let's list turnsAway from index 3:
+    // P3 (idx 3) -> 0
+    // P0 (idx 0) -> 1  (score 3000)
+    // P1 (idx 1) -> 2  (score 4000)
+    // P2 (idx 2) -> 3  (score 4000)
+    // Rank logic:
+    // 1st: P3 (4000, 0)
+    // 2nd: P1 (4000, 2)
+    // 3rd: P2 (4000, 3)
+    // 4th: P0 (3000, 1) - score overrides turnsAway
+    TEST_ASSERT_EQUAL_INT(4, game.state.rankedPlayerIndices.size());
+    TEST_ASSERT_EQUAL_INT(3, game.state.rankedPlayerIndices[0]);
+    TEST_ASSERT_EQUAL_INT(1, game.state.rankedPlayerIndices[1]);
+    TEST_ASSERT_EQUAL_INT(2, game.state.rankedPlayerIndices[2]);
+    TEST_ASSERT_EQUAL_INT(0, game.state.rankedPlayerIndices[3]);
+}
+
 void run_waiting_phase_tests() {
+    RUN_TEST(test_WaitingPhase_TieBreakerSorting);
     RUN_TEST(test_WaitingPhase_ScoreAccumulation);
     RUN_TEST(test_WaitingPhase_LeaderboardScrolling);
     RUN_TEST(test_WaitingPhase_ScoreCorrection);

--- a/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.h
+++ b/src/farkle/test/test_game_logic/small_tests/test_WaitingPhase.h
@@ -5,6 +5,7 @@ void test_WaitingPhase_ScoreAccumulation();
 void test_WaitingPhase_ScoreCorrection();
 void test_WaitingPhase_TransitionToBanking();
 void test_WaitingPhase_TransitionToFarkling();
+void test_WaitingPhase_TieBreakerSorting();
 
 void run_waiting_phase_tests();
 


### PR DESCRIPTION
Updates the leaderboard and end-of-game tiebreaker logic to accurately prefer the player whose turn occurs sooner when scores are tied. This secondary logic sorts the leaderboard ascending by `turnsAwayFromPlayer`. End-of-game logic was refactored to rely purely on this newly robust leaderboard calculation.

---
*PR created automatically by Jules for task [4955339523767827331](https://jules.google.com/task/4955339523767827331) started by @gwenrich136*