### PR TITLE
docs: Document 5V to 3.3V Logic Level Converter requirement for SD Card

### DIFF
--- a/design/HARDWARE_UPGRADE_MIGRATION_PLAN.md
+++ b/design/HARDWARE_UPGRADE_MIGRATION_PLAN.md
@@ -94,7 +94,7 @@ To accommodate the increased pin cost of the SPI LCD while preserving hardware e
 
 ### **Phase 3: Persistence & Audio**
 **Step 6: SD Card Storage (D9)**
-*   **Hardware Requirement:** The Arduino Uno R4 WiFi operates on **5V logic**, while SD Card modules operate on **3.3V logic**. A **5V-to-3.3V Logic Level Converter** MUST be installed on the SPI bus (D11, D13, D9) between the Arduino and the SD Card module to prevent permanent damage to the module. Alternatively, an SD Card module with built-in level shifting can be used.
+*   **Hardware Requirement:** The SD Card module **MUST** natively support 5V operation. Because the Arduino Uno R4 WiFi uses 5V logic for its SPI bus, utilizing a bare 3.3V SD module will cause damage or data corruption. Ensure the module has a built-in logic level shifter.
 
 **Step 7: MP3 Audio (D0/D1)**
 

--- a/design/HARDWARE_UPGRADE_MIGRATION_PLAN.md
+++ b/design/HARDWARE_UPGRADE_MIGRATION_PLAN.md
@@ -94,6 +94,8 @@ To accommodate the increased pin cost of the SPI LCD while preserving hardware e
 
 ### **Phase 3: Persistence & Audio**
 **Step 6: SD Card Storage (D9)**
+*   **Hardware Requirement:** The Arduino Uno R4 WiFi operates on **5V logic**, while SD Card modules operate on **3.3V logic**. A **5V-to-3.3V Logic Level Converter** MUST be installed on the SPI bus (D11, D13, D9) between the Arduino and the SD Card module to prevent permanent damage to the module. Alternatively, an SD Card module with built-in level shifting can be used.
+
 **Step 7: MP3 Audio (D0/D1)**
 
 ---

--- a/design/SCHEMATIC_AND_HARDWARE_GUIDE.md
+++ b/design/SCHEMATIC_AND_HARDWARE_GUIDE.md
@@ -86,11 +86,6 @@ graph TD
     GND\_BUS\[Common Ground Bus\]  
     end
 
-    subgraph Level_Shifter ["Logic Level Converter (5V to 3.3V)"]
-    LV_5V[5V Side]
-    LV_3V[3.3V Side]
-    end
-
     subgraph Arduino \["Arduino Uno R4 WiFi"\]  
     A\_5V\[5V Pin\]  
     A\_GND\[GND Pin\]  
@@ -119,7 +114,7 @@ graph TD
     SPK\["MP3 Player + Speaker"\]  
     BTNS\["Hybrid Control Pad"\]  
     STRIP\["8-LED Status Strip"\]  
-    SD["SD Card Module (3.3V Logic)"]
+    SD\["SD Card Module (5V Native)"\]
     end
 
     %% USB Connection  
@@ -146,12 +141,10 @@ graph TD
     %% Shared SPI Bus
     D11 \--\> MAX
     D11 \--\> LCD
-    D11 --> LV_5V
-    LV_3V --> SD
+    D11 \--\> SD
     D13 \--\> MAX
     D13 \--\> LCD
-    D13 --> LV_5V
-    LV_3V --> SD
+    D13 \--\> SD
 
     %% Dedicated Control Signals  
     A0 \--\> NEO  
@@ -160,8 +153,7 @@ graph TD
     A5 \--\> LCD
     D7 \--\> LCD
     D8 \--\> LCD
-    D9 --> LV_5V
-    LV_3V --> SD
+    D9 \--\> SD
     D4 \--\> BTNS
     D5 \--\> BTNS
     D6 \--\> BTNS
@@ -181,9 +173,9 @@ Both the **Score Displays** and the **IPS LCD** share the hardware SPI clock and
 | **D13** | **SCK (Clock)** | Shared Bus | **CLK** (Score) / **SCL** (LCD) |
 | **D10** | **CS (Load)** | **Score Display** | **CS** |
 | **A4** | **CS** | **ST7789 LCD** | **CS** (or GND if missing) |
-| **D9** | **CS** | **SD Card** | **CS** (via Level Shifter) |
+| **D9** | **CS** | **SD Card** | **CS** |
 
-> **⚠️ CRITICAL LOGIC LEVEL WARNING:** The Arduino Uno R4 WiFi uses **5V logic**, while standard SD Card modules often operate on **3.3V logic**. Connecting 5V SPI signals (MOSI, SCK, CS) directly to a 3.3V SD card module will fry the card and the module. You **must** use a 5V-to-3.3V Logic Level Converter inline on pins D9, D11, and D13, or purchase an SD Card module that explicitly features built-in level shifting.
+> **⚠️ CRITICAL HARDWARE REQUIREMENT:** The Arduino Uno R4 WiFi operates on **5V logic**. You **MUST** use an SD Card module that explicitly features a built-in logic level shifter and 5V voltage regulator (e.g., those built with LVC125A or similar chips). Do not use bare 3.3V SD card modules directly on the SPI bus.
 
 ### **2. IPS Color LCD (ST7789)**
 | Arduino Pin | Signal | Notes |

--- a/design/SCHEMATIC_AND_HARDWARE_GUIDE.md
+++ b/design/SCHEMATIC_AND_HARDWARE_GUIDE.md
@@ -86,6 +86,11 @@ graph TD
     GND\_BUS\[Common Ground Bus\]  
     end
 
+    subgraph Level_Shifter ["Logic Level Converter (5V to 3.3V)"]
+    LV_5V[5V Side]
+    LV_3V[3.3V Side]
+    end
+
     subgraph Arduino \["Arduino Uno R4 WiFi"\]  
     A\_5V\[5V Pin\]  
     A\_GND\[GND Pin\]  
@@ -114,7 +119,7 @@ graph TD
     SPK\["MP3 Player + Speaker"\]  
     BTNS\["Hybrid Control Pad"\]  
     STRIP\["8-LED Status Strip"\]  
-    SD\["SD Card Module"\]
+    SD["SD Card Module (3.3V Logic)"]
     end
 
     %% USB Connection  
@@ -141,10 +146,12 @@ graph TD
     %% Shared SPI Bus
     D11 \--\> MAX
     D11 \--\> LCD
-    D11 \--\> SD
+    D11 --> LV_5V
+    LV_3V --> SD
     D13 \--\> MAX
     D13 \--\> LCD
-    D13 \--\> SD
+    D13 --> LV_5V
+    LV_3V --> SD
 
     %% Dedicated Control Signals  
     A0 \--\> NEO  
@@ -153,7 +160,8 @@ graph TD
     A5 \--\> LCD
     D7 \--\> LCD
     D8 \--\> LCD
-    D9 \--\> SD
+    D9 --> LV_5V
+    LV_3V --> SD
     D4 \--\> BTNS
     D5 \--\> BTNS
     D6 \--\> BTNS
@@ -173,7 +181,9 @@ Both the **Score Displays** and the **IPS LCD** share the hardware SPI clock and
 | **D13** | **SCK (Clock)** | Shared Bus | **CLK** (Score) / **SCL** (LCD) |
 | **D10** | **CS (Load)** | **Score Display** | **CS** |
 | **A4** | **CS** | **ST7789 LCD** | **CS** (or GND if missing) |
-| **D9** | **CS** | **SD Card** | **CS** |
+| **D9** | **CS** | **SD Card** | **CS** (via Level Shifter) |
+
+> **⚠️ CRITICAL LOGIC LEVEL WARNING:** The Arduino Uno R4 WiFi uses **5V logic**, while standard SD Card modules often operate on **3.3V logic**. Connecting 5V SPI signals (MOSI, SCK, CS) directly to a 3.3V SD card module will fry the card and the module. You **must** use a 5V-to-3.3V Logic Level Converter inline on pins D9, D11, and D13, or purchase an SD Card module that explicitly features built-in level shifting.
 
 ### **2. IPS Color LCD (ST7789)**
 | Arduino Pin | Signal | Notes |


### PR DESCRIPTION
Updates the hardware migration plan and schematic guide to explicitly state that a Logic Level Converter is required on the SPI bus between the 5V Arduino Uno R4 WiFi and the 3.3V SD Card module. Directly wiring 5V SPI to a 3.3V module risks frying the module or corrupting data. Resistor voltage dividers are also contraindicated for high-speed SPI signals.

---
*PR created automatically by Jules for task [2562176213718006220](https://jules.google.com/task/2562176213718006220) started by @gwenrich136*