### PR TITLE
Refactor test setup flow

### DIFF
--- a/design/TESTING_STRATEGY.md
+++ b/design/TESTING_STRATEGY.md
@@ -288,3 +288,8 @@ To prevent phantom inputs when pressing multiple buttons on the bus (like the Gh
 ### 7.4 No-Repeat & Undefined States
 *   **Single Trigger**: Holding a bus button (e.g., `PLUS_50`) must result in exactly one action. A return to the "Neutral" bus state (0) is required before another action can be triggered.
 *   **Undefined States**: Ensure that any unmapped decimal bus values default gracefully to `ButtonAction::NONE`.
+
+## 8. Setup and Pregame Flow Principles
+To ensure tests are concise, robust, and fast, the following setup principles must be adhered to:
+1.  **Direct State Setup:** For all small and intermediate (medium) game logic tests, do NOT simulate the pregame flow (Target Score Selection, Player Selection). Use the provided `setupGameWithPlayers` helper, which directly constructs the game state internally, forces a jump to `WaitingPhase`, and bypasses the lengthy initial user interface sequences.
+2.  **Full Lifecycle Simulation:** For large end-to-end tests (or tests specifically designed to verify the pregame phase input logic), use the `simulatePregameFlow` helper to walk through the actual button inputs and rotation commands required to set up and start a game.

--- a/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
+++ b/src/farkle/test/test_game_logic/large_tests/test_full_game.cpp
@@ -11,7 +11,7 @@ void advance_to_player_zero(Game& game);
 // Simulates a full game where players take turns scoring until one player reaches the target score, triggering the final round.
 void test_FullGame_StandardGame() {
     Game game;
-    setupGameWithPlayers(game, 4);
+    simulatePregameFlow(game, 4);
 
     int turn = 0;
     while (game.currentPhase != game.getPhase<PostGamePhase_V1>() && turn < 100) {
@@ -40,7 +40,7 @@ void test_FullGame_StandardGame() {
 // Verifies that finalizeGame is called exactly once regardless of how many loops run in PostGamePhase_V1
 void test_PostGame_FinalizeCalledOnce() {
     Game game;
-    setupGameWithPlayers(game, 2);
+    simulatePregameFlow(game, 2);
 
     // Get player 0 to 9500 points
     game.state.players[0].score = 9500;
@@ -72,7 +72,7 @@ void test_PostGame_FinalizeCalledOnce() {
 // Test function to verify the triple farkle penalty and reset behavior
 void test_FullGame_TripleFarkle() {
     Game game;
-    setupGameWithPlayers(game, 4);
+    simulatePregameFlow(game, 4);
     game.state.players[0].score = 2500; // Give player 1 some points
 
     // --- First Farkle ---
@@ -108,7 +108,7 @@ void test_FullGame_TripleFarkle() {
 
 void test_FullGame_TripleFarkle_ScoreLessThanPenalty() {
     Game game;
-    setupGameWithPlayers(game, 4);
+    simulatePregameFlow(game, 4);
 
     // --- Player 0 scores 500 points ---
     simulateButtonPress(game, ButtonAction::PLUS_500);
@@ -152,7 +152,7 @@ void test_FullGame_TripleFarkle_ScoreLessThanPenalty() {
 
 void test_FullGame_AutoAdvanceTurn() {
     Game game;
-    setupGameWithPlayers(game, 4);
+    simulatePregameFlow(game, 4);
 
     int turn = 0;
     while (game.currentPhase != game.getPhase<PostGamePhase_V1>() && turn < 100) {
@@ -180,7 +180,7 @@ void test_FullGame_AutoAdvanceTurn() {
 // Verifies that the Competition Score display begins blinking as soon as the final round is triggered.
 void test_FullGame_FinalRoundBlinking() {
     Game game;
-    setupGameWithPlayers(game, 2);
+    simulatePregameFlow(game, 2);
 
     // Player 0 is about to reach the target score (10,000)
     game.state.players[0].score = 9500;
@@ -217,7 +217,7 @@ void test_FullGame_FinalRoundBlinking() {
 // Full Game With Score Toggle Simulation
 void test_FullGame_ScoreToggle() {
     Game game;
-    setupGameWithPlayers(game, 2);
+    simulatePregameFlow(game, 2);
 
     // Toggle switch to PENDING
     game.controlPad.setToggleState(ScoreDisplayMode::PENDING);

--- a/src/farkle/test/test_game_logic/test_utils.cpp
+++ b/src/farkle/test/test_game_logic/test_utils.cpp
@@ -1,5 +1,6 @@
 #include "test_utils.h"
 #include "Arduino.h"
+#include "phases/WaitingPhase.h"
 
 void simulateButtonPress(Game& game, ButtonAction action, int count, unsigned long advance_time_millis) {
     for (int i = 0; i < count; ++i) {
@@ -16,6 +17,35 @@ void simulateRotation(Game& game, int delta, unsigned long advance_time_millis) 
 }
 
 void setupGameWithPlayers(Game& game, int numPlayers) {
+    game.setup();
+
+    // Directly populate players and skip the pregame phases.
+    const char* names[] = {"Geewee", "Sammy", "Coach", "Sheshe", "Alex", "Tigre", "Pepa", "Fred", "Andrea"};
+    for (int i = 0; i < numPlayers; ++i) {
+        game.addPlayer(names[i]);
+    }
+
+    // Set target score explicitly
+    game.setTargetScore(10000);
+
+    // Enter WaitingPhase directly
+    game.currentPhase = game.getPhase<WaitingPhase>();
+    game.currentPhase->onEnter(game.state);
+
+    // Mock MemoryCard behaviors that are usually initialized in PlayerSelectionPhase
+    game.getMemoryCard().mock_getOrGenerateNextGameId_called = true;
+    game.getMemoryCard().mock_initializeGameDirectory_called = true;
+    game.getMemoryCard().mock_initializeGameDirectory_arg = 42;
+    game.getMemoryCard().mock_writeGameMetadata_called = true;
+    game.getMemoryCard().mock_writeGameMetadata_arg = 42;
+    game.getMemoryCard().mock_setActiveGameId_called = true;
+    game.getMemoryCard().mock_setActiveGameId_arg = 42;
+
+    // Optional: do one game.loop() to ensure the internal displays and tracking are flushed.
+    game.loop();
+}
+
+void simulatePregameFlow(Game& game, int numPlayers) {
     game.setup();
 
     // 1. Transition from TargetScoreSelectionPhase to PlayerSelectionPhase

--- a/src/farkle/test/test_game_logic/test_utils.h
+++ b/src/farkle/test/test_game_logic/test_utils.h
@@ -10,5 +10,6 @@ void simulateRotation(Game& game, int delta, unsigned long advance_time_millis =
 void simulateNoAction(Game& game, unsigned long advance_time_millis = 10);
 void waitForScoreAnimation(Game& game);
 void setupGameWithPlayers(Game& game, int numPlayers);
+void simulatePregameFlow(Game& game, int numPlayers);
 
 #endif // TEST_UTILS_H


### PR DESCRIPTION
Refactor the test setup code by extracting the manual setup into `simulatePregameFlow` while retaining an instantaneous internal state setup for `setupGameWithPlayers`. This ensures large tests can still run an e2e style test, while making the small test cases not reliant on testing pregame input logic explicitly.

---
*PR created automatically by Jules for task [9080107994775806043](https://jules.google.com/task/9080107994775806043) started by @gwenrich136*