### PR TITLE
feat: Add initial StartupPhase to game sequence

### DIFF
--- a/design/PRE_GAME_PHASES.md
+++ b/design/PRE_GAME_PHASES.md
@@ -11,9 +11,22 @@ The goal of this category is to populate the `GameState` with the necessary info
 
 ## 3. Phase Relationships
 The system follows this sequence:
-`TargetScoreSelectionPhase` -> `PlayerSelectionPhase` -> `WaitingPhase` (In-Game)
+`StartupPhase` -> `TargetScoreSelectionPhase` -> `PlayerSelectionPhase` -> `WaitingPhase` (In-Game)
 
 ## 4. Technical Details
+
+### StartupPhase
+*   **Why:** Serves as the absolute first entry point for the game upon boot. Currently functions as a dummy phase to introduce the UI layer but will be expanded with more options later.
+*   **Inherits From:** `PreGamePhase`
+*   **Defined in:** `src/farkle/include/phases/StartupPhase.h` & `src/farkle/src/phases/StartupPhase.cpp`
+*   **Implementation Details:**
+    1.  **Selection Logic**: Currently provides a single static option, "New Game".
+    2.  **Navigation**: No other items to navigate to. Encoder rotations are ignored.
+    3.  **Confirmation (SELECT)**:
+        *   Transitions the user to the `TargetScoreSelectionPhase`.
+    4.  **Display Behavior (Hooks)**:
+        *   **`updateTextDisplay()`**: Calls `textDisplay.printSelectionScreen("Farkle!", "New Game")`.
+        *   **`updateProgressGrid()`**: The grid is already cleared via `Game::resetGame()`.
 
 ### PreGamePhase
 *   **Why:** Intermediate class for all pre-game states. It provides shared display behavior and ensures the scoreboard's secondary displays are used consistently during setup.

--- a/src/farkle/include/Game.h
+++ b/src/farkle/include/Game.h
@@ -7,6 +7,7 @@
 #include "GamePhase.h"
 #include <type_traits>
 
+#include "phases/StartupPhase.h"
 #include "phases/TargetScoreSelectionPhase.h"
 #include "phases/PlayerSelectionPhase.h"
 #include "phases/WaitingPhase.h"
@@ -33,6 +34,7 @@ public:
     // Templated helper to get a pointer to a specific phase from the pool
     template<typename T>
     T* getPhase() {
+        if (std::is_same<T, StartupPhase>::value) return (T*)&phasePool.startup;
         if (std::is_same<T, TargetScoreSelectionPhase>::value) return (T*)&phasePool.targetScoreSelection;
         if (std::is_same<T, PlayerSelectionPhase>::value) return (T*)&phasePool.playerSelection;
         if (std::is_same<T, WaitingPhase>::value) return (T*)&phasePool.waiting;
@@ -56,6 +58,7 @@ public:
 private:
 #endif
     struct PhasePool {
+        StartupPhase startup;
         TargetScoreSelectionPhase targetScoreSelection;
         PlayerSelectionPhase playerSelection;
         WaitingPhase waiting;

--- a/src/farkle/include/phases/StartupPhase.h
+++ b/src/farkle/include/phases/StartupPhase.h
@@ -1,0 +1,15 @@
+#ifndef StartupPhase_h
+#define StartupPhase_h
+
+#include "GamePhase.h"
+
+class StartupPhase : public PreGamePhase {
+public:
+    virtual void onEnter(GameState& state) override;
+    virtual GamePhase* update(Game& game, GameState& state, GameInput input, unsigned long deltaTime) override;
+
+protected:
+    virtual void updateTextDisplay(const GameState& state, const Displays& displays) override;
+};
+
+#endif

--- a/src/farkle/src/Game.cpp
+++ b/src/farkle/src/Game.cpp
@@ -45,7 +45,7 @@ void Game::setup() {
     resetGame();
 
     // 3. Set Initial State
-    currentPhase = &phasePool.targetScoreSelection;
+    currentPhase = &phasePool.startup;
     currentPhase->onEnter(state);
     
     lastUpdateTime = millis();

--- a/src/farkle/src/phases/StartupPhase.cpp
+++ b/src/farkle/src/phases/StartupPhase.cpp
@@ -1,0 +1,18 @@
+#include "phases/StartupPhase.h"
+#include "Game.h"
+
+void StartupPhase::onEnter(GameState& state) {
+    // Initial dummy state
+}
+
+GamePhase* StartupPhase::update(Game& game, GameState& state, GameInput input, unsigned long deltaTime) {
+    if (input.action == ButtonAction::SELECT) {
+        return game.getPhase<TargetScoreSelectionPhase>();
+    }
+
+    return this;
+}
+
+void StartupPhase::updateTextDisplay(const GameState& state, const Displays& displays) {
+    displays.textDisplay.printSelectionScreen("Farkle!", "New Game");
+}

--- a/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
+++ b/src/farkle/test/test_game_logic/medium_tests/test_turn_lifecycle.cpp
@@ -20,6 +20,14 @@ void test_TurnLifecycle_FullSetupAndTurn() {
     game.setup();
     game.loop();
 
+    // 0. Startup Phase
+    TEST_ASSERT_EQUAL_STRING("Farkle!", game.textDisplay.captured_title.c_str());
+    TEST_ASSERT_EQUAL_STRING("New Game", game.textDisplay.captured_item.c_str());
+
+    // Transition to Target Score Selection
+    simulateButtonPress(game, ButtonAction::SELECT);
+    game.loop();
+
     // 1. Target Score Selection
     TEST_ASSERT_EQUAL_STRING("Target Score", game.textDisplay.captured_title.c_str());
     TEST_ASSERT_EQUAL_STRING("10,000", game.textDisplay.captured_item.c_str());

--- a/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_PlayerSelectionPhase.cpp
@@ -4,14 +4,18 @@
 #include <unity.h>
 #include "Arduino.h"
 
+// Helper function to setup game and transition to PlayerSelectionPhase
+void setup_and_transition_to_player_selection(Game& game) {
+    game.setup();
+    simulateButtonPress(game, ButtonAction::SELECT); // Transition from StartupPhase to TargetScore
+    simulateButtonPress(game, ButtonAction::SELECT); // Transition from TargetScore to PlayerSelection
+    game.loop(); // Run one extra loop to allow MemoryCard to initialize
+}
+
 // Verifies that the phase starts with the first name in the pool ("Geewee") and an empty player list.
 void test_PlayerSelection_InitialState() {
     Game game;
-    game.setup();
-
-    // Transition to PlayerSelectionPhase
-    simulateButtonPress(game, ButtonAction::SELECT);
-    game.loop(); // Run one extra loop to allow MemoryCard to initialize
+    setup_and_transition_to_player_selection(game);
 
     // Should be in PlayerSelectionPhase
     TEST_ASSERT_EQUAL_STRING("Add Player", game.textDisplay.captured_title.c_str());
@@ -22,9 +26,7 @@ void test_PlayerSelection_InitialState() {
 // Verifies that rotation increments and decrements the name list correctly, including boundaries.
 void test_PlayerSelection_Cycling() {
     Game game;
-    game.setup();
-    simulateButtonPress(game, ButtonAction::SELECT);
-    game.loop();
+    setup_and_transition_to_player_selection(game);
 
     // Next name
     simulateRotation(game, 1);
@@ -50,9 +52,7 @@ void test_PlayerSelection_Cycling() {
 // Verifies that pressing SELECT adds the selected name and the selection "stays in place" (shifts to next name).
 void test_PlayerSelection_AddPlayer() {
     Game game;
-    game.setup();
-    simulateButtonPress(game, ButtonAction::SELECT);
-    game.loop();
+    setup_and_transition_to_player_selection(game);
 
     // Navigate to Sammy (index 1)
     simulateRotation(game, 1);
@@ -74,9 +74,7 @@ void test_PlayerSelection_AddPlayer() {
 // Verifies that multiple added players are all removed from the selection list and index stays valid.
 void test_PlayerSelection_Filtering() {
     Game game;
-    game.setup();
-    simulateButtonPress(game, ButtonAction::SELECT);
-    game.loop();
+    setup_and_transition_to_player_selection(game);
 
     // Add Geewee (index 0)
     simulateButtonPress(game, ButtonAction::SELECT);
@@ -96,10 +94,9 @@ void test_PlayerSelection_Filtering() {
 // Verifies that the game cannot start with 0 players but successfully transitions with >= 1.
 void test_PlayerSelection_TransitionValidation() {
     Game game;
-    game.setup();
+    setup_and_transition_to_player_selection(game);
 
     // Cannot start with 0 players
-    simulateButtonPress(game, ButtonAction::SELECT); // Transition from TargetScore to PlayerSelection
     simulateButtonPress(game, ButtonAction::FARKLE); // Try to start with 0
     TEST_ASSERT_EQUAL_STRING("Add Player", game.textDisplay.captured_title.c_str());
 
@@ -140,9 +137,7 @@ void test_PlayerSelection_TransitionValidation() {
 // Verifies that the phase respects the 8-player hardware limit and shows "ROSTER FULL" using a simple print.
 void test_PlayerSelection_MaxPlayers() {
     Game game;
-    game.setup();
-    simulateButtonPress(game, ButtonAction::SELECT);
-    game.loop();
+    setup_and_transition_to_player_selection(game);
 
     // Add 8 players
     simulateButtonPress(game, ButtonAction::SELECT, 8);
@@ -159,9 +154,7 @@ void test_PlayerSelection_MaxPlayers() {
 // Verifies that adding the last name in the filtered pool falls back to the previous name, not wrapping to 0.
 void test_PlayerSelection_AddLastPlayerFallsBack() {
     Game game;
-    game.setup();
-    simulateButtonPress(game, ButtonAction::SELECT);
-    game.loop();
+    setup_and_transition_to_player_selection(game);
 
     // Pool size is 9. Move to last (index 8: Andrea)
     for(int i=0; i<8; ++i) simulateRotation(game, 1);

--- a/src/farkle/test/test_game_logic/small_tests/test_StartupPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_StartupPhase.cpp
@@ -1,0 +1,59 @@
+#include "test_StartupPhase.h"
+#include "Game.h"
+#include "../test_utils.h"
+#include <unity.h>
+#include "Arduino.h"
+
+// Verifies that the phase starts correctly and displays the correct title and item.
+void test_StartupPhase_InitialState() {
+    Game game;
+    game.setup();
+    game.loop();
+
+    // Should start in StartupPhase
+    TEST_ASSERT_EQUAL_STRING("Farkle!", game.textDisplay.captured_title.c_str());
+    TEST_ASSERT_EQUAL_STRING("New Game", game.textDisplay.captured_item.c_str());
+}
+
+// Verifies that pressing SELECT transitions to TargetScoreSelectionPhase.
+void test_StartupPhase_Transition() {
+    Game game;
+    game.setup();
+
+    // Transition with SELECT
+    simulateButtonPress(game, ButtonAction::SELECT);
+
+    // Should be in TargetScoreSelectionPhase
+    TEST_ASSERT_EQUAL_STRING("Target Score", game.textDisplay.captured_title.c_str());
+}
+
+// Verifies that rotating does nothing.
+void test_StartupPhase_IgnoreRotation() {
+    Game game;
+    game.setup();
+
+    simulateRotation(game, 1);
+    TEST_ASSERT_EQUAL_STRING("Farkle!", game.textDisplay.captured_title.c_str());
+
+    simulateRotation(game, -1);
+    TEST_ASSERT_EQUAL_STRING("Farkle!", game.textDisplay.captured_title.c_str());
+}
+
+// Verifies that other buttons do nothing.
+void test_StartupPhase_IgnoreOtherButtons() {
+    Game game;
+    game.setup();
+
+    simulateButtonPress(game, ButtonAction::FARKLE);
+    TEST_ASSERT_EQUAL_STRING("Farkle!", game.textDisplay.captured_title.c_str());
+
+    simulateButtonPress(game, ButtonAction::BANK);
+    TEST_ASSERT_EQUAL_STRING("Farkle!", game.textDisplay.captured_title.c_str());
+}
+
+void run_startup_phase_tests() {
+    RUN_TEST(test_StartupPhase_InitialState);
+    RUN_TEST(test_StartupPhase_Transition);
+    RUN_TEST(test_StartupPhase_IgnoreRotation);
+    RUN_TEST(test_StartupPhase_IgnoreOtherButtons);
+}

--- a/src/farkle/test/test_game_logic/small_tests/test_StartupPhase.h
+++ b/src/farkle/test/test_game_logic/small_tests/test_StartupPhase.h
@@ -1,0 +1,6 @@
+#ifndef test_StartupPhase_h
+#define test_StartupPhase_h
+
+void run_startup_phase_tests();
+
+#endif

--- a/src/farkle/test/test_game_logic/small_tests/test_TargetScoreSelectionPhase.cpp
+++ b/src/farkle/test/test_game_logic/small_tests/test_TargetScoreSelectionPhase.cpp
@@ -4,13 +4,19 @@
 #include <unity.h>
 #include "Arduino.h"
 
+// Helper function to setup game and transition to TargetScoreSelectionPhase
+void setup_and_transition_to_target_score_selection(Game& game) {
+    game.setup();
+    simulateButtonPress(game, ButtonAction::SELECT); // Transition from StartupPhase
+    game.loop();
+}
+
 // Verifies that the phase starts with the default target score (10,000).
 void test_TargetScoreSelection_InitialState() {
     Game game;
-    game.setup();
-    game.loop();
+    setup_and_transition_to_target_score_selection(game);
 
-    // Should start in TargetScoreSelectionPhase
+    // Should be in TargetScoreSelectionPhase
     TEST_ASSERT_EQUAL_STRING("Target Score", game.textDisplay.captured_title.c_str());
     TEST_ASSERT_EQUAL_STRING("10,000", game.textDisplay.captured_item.c_str());
     TEST_ASSERT_EQUAL_INT(10000, game.state.targetScore);
@@ -19,7 +25,7 @@ void test_TargetScoreSelection_InitialState() {
 // Verifies that rotation increments and decrements the target score correctly.
 void test_TargetScoreSelection_Adjustment() {
     Game game;
-    game.setup();
+    setup_and_transition_to_target_score_selection(game);
 
     // Increment (1 click = 1000)
     simulateRotation(game, 1);
@@ -35,7 +41,7 @@ void test_TargetScoreSelection_Adjustment() {
 // Verifies that the target score is clamped between 1,000 and 20,000.
 void test_TargetScoreSelection_Clamping() {
     Game game;
-    game.setup();
+    setup_and_transition_to_target_score_selection(game);
 
     // Test Lower Bound
     // Start at 10,000. Go down 15,000 (15 clicks).
@@ -68,7 +74,7 @@ void test_TargetScoreSelection_Clamping() {
 // Verifies that pressing SELECT transitions to PlayerSelectionPhase, and BANK/FARKLE do not.
 void test_TargetScoreSelection_Transition() {
     Game game;
-    game.setup();
+    setup_and_transition_to_target_score_selection(game);
 
     // Change score to 5000
     for (int i = 0; i < 5; ++i) {

--- a/src/farkle/test/test_game_logic/test_main.cpp
+++ b/src/farkle/test/test_game_logic/test_main.cpp
@@ -1,5 +1,6 @@
 #include <unity.h>
 
+#include "small_tests/test_StartupPhase.h"
 #include "small_tests/test_TargetScoreSelectionPhase.h"
 #include "small_tests/test_PlayerSelectionPhase.h"
 #include "small_tests/test_WaitingPhase.h"
@@ -25,6 +26,7 @@ void tearDown(void) {
 }
 
 void test_runner() {
+    run_startup_phase_tests();
     run_target_score_selection_phase_tests();
     run_player_selection_phase_tests();
     run_waiting_phase_tests();

--- a/src/farkle/test/test_game_logic/test_utils.cpp
+++ b/src/farkle/test/test_game_logic/test_utils.cpp
@@ -48,6 +48,10 @@ void setupGameWithPlayers(Game& game, int numPlayers) {
 void simulatePregameFlow(Game& game, int numPlayers) {
     game.setup();
 
+    // 0. Transition from StartupPhase to TargetScoreSelectionPhase
+    simulateButtonPress(game, ButtonAction::SELECT);
+    game.loop();
+
     // 1. Transition from TargetScoreSelectionPhase to PlayerSelectionPhase
     simulateButtonPress(game, ButtonAction::SELECT);
     game.loop();


### PR DESCRIPTION
This PR introduces a new `StartupPhase` to serve as the very first screen users see when the game boots up. It acts as a foundational UI layer for future menu expansion, currently offering a single "New Game" option. The phase correctly handles user input, transitioning to the `TargetScoreSelectionPhase` only when the SELECT button is pressed, and ignoring rotations or other game inputs.

Key changes:
1. Created `StartupPhase` component inheriting from `PreGamePhase`.
2. Wired `StartupPhase` into `Game::setup()` as the initial state.
3. Added robust unit testing for the new phase to verify input handling and rendering logic.
4. Refactored existing game logic tests using helper functions (e.g., `setup_and_transition_to_target_score_selection`) to DRY up the setup phase and simulate the new transition accurately.
5. Updated `PRE_GAME_PHASES.md` documentation to accurately capture the new flow diagram and phase details.

---
*PR created automatically by Jules for task [10792089756557560330](https://jules.google.com/task/10792089756557560330) started by @gwenrich136*